### PR TITLE
Fixed django import issue; implemented solution for topbar problems

### DIFF
--- a/custom_code/templates/custom_code/partials/time_usage_bars.html
+++ b/custom_code/templates/custom_code/partials/time_usage_bars.html
@@ -1,15 +1,15 @@
 <table cellpadding=0 cellspacing=0 border=0>
   <tr valign=center>
-    <td><span style="color:#ececec; padding-right: 5px; padding-left: 5px;">{{ telescope }} Usage:</span></td>
+    <td><span style="color:#ececec; padding-right: 5px; padding-left: 5px;">{{ telescope }}:</span></td>
     <td>
-      <table cellpadding=0 cellspacing=0 border=0 style="width: 100px; height: 25px; table-layout: fixed;">
+      <table cellpadding=0 cellspacing=0 border=0 style="width: 5vw; height: 25px; table-layout: fixed;">
         <tr style="height: 6px;" valign="bottom">
           <td style="width: {{ barwidth }}%;"</td>
           <td style="width: 10px; text-align: center; font-size: 8px;"><span style="color: #ececec;">&#9660;</span></td>
         </tr>
         <tr>
           <td colspan=3>
-            <table cellpadding=0 cellspacing=0 style="width: 100px; height: 13px; border: 1px solid #cccccc;">
+            <table cellpadding=0 cellspacing=0 style="width: 5vw; height: 13px; border: 1px solid #cccccc;">
               <tr title="{{ tooltip }}">
               <td width="{{ usedbarwidth }}" bgcolor="{{ barcolor }}"></td>
         	    <td bgcolor="#cccccc"></td>
@@ -17,7 +17,7 @@
             </table>
           </td>
         </tr>
-        <tr style="height: 6px;" valign="top">
+        <tr style="height: 6px; width: 5vw;" valign="top">
           <td style="width: {{ barwidth }};"></td>
           <td valign="top" style="width: 5px; text-align: center;"><span style="line-height: 4px; color: #ececec;"></span></td>
         </tr>

--- a/custom_code/views.py
+++ b/custom_code/views.py
@@ -27,7 +27,7 @@ from django.contrib.auth.models import User, Group
 from django.contrib.contenttypes.models import ContentType
 from django.contrib import messages
 from django.conf import settings
-from django.contrib.postgres.fields.jsonb import KeyTextTransform
+from django.db.models.fields.json import KeyTextTransform
 
 import os
 from urllib.parse import urlencode

--- a/templates/tom_common/base.html
+++ b/templates/tom_common/base.html
@@ -20,7 +20,7 @@
   </head>
   <body>
     <!--<nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">-->
-    <nav class="navbar navbar-expand-md fixed-top">
+    <nav class="navbar navbar-expand-md fixed-top" style="align-self: center;padding: 10px;">
       <a class="navbar-brand" href="/"><img src="{% static 'tom_common/img/logo-color-cropped.png' %}" class="img-fluid">SNEx 2.0</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
@@ -29,10 +29,10 @@
       <div class="collapse navbar-collapse" id="navbarsExampleDefault">
         <ul class="navbar-nav mr-auto">
           <li class="nav-item {% if request.resolver_match.url_name == 'home' %}active{% endif %}">
-            <a class="nav-link" href="/" style="font-family: 'Montserrat', sans-serif;">Home <span class="sr-only">(current)</span></a>
+            <a class="nav-link" href="/" style="font-family: 'Montserrat', sans-serif; font-size:1.25vw;">Home <span class="sr-only">(current)</span></a>
           </li>
           <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" data-toggle="dropdown" style="font-family: 'Montserrat', sans-serif;">Targets</a>
+            <a class="nav-link dropdown-toggle" data-toggle="dropdown" style="font-family: 'Montserrat', sans-serif; font-size:1.25vw;">Targets</a>
             <ul class="dropdown-menu">
               <li class="nav-item {% if request.resolver_match.namespace == 'targets' %}active{% endif %}">
                 <a class="nav-link" href="{% url 'targets:list' %}"><font color="black">Targets</font></a>
@@ -44,7 +44,7 @@
             </ul>
           </li>
 	  <li class="nav-item dropdown">
-	    <a class="nav-link dropdown-toggle" data-toggle="dropdown" style="font-family: 'Montserrat', sans-serif;">Alerts</a>
+	    <a class="nav-link dropdown-toggle" data-toggle="dropdown" style="font-family: 'Montserrat', sans-serif; font-size:1.25vw;">Alerts</a>
 	    <ul class="dropdown-menu">
               <li class="nav-item {% if request.resolver_match.namespace == 'alerts' %}active{% endif %}">
 		<a class="nav-link" href="{% url 'alerts:list' %}"><Font color="black">Make a Query</font></a>
@@ -53,29 +53,29 @@
 	    </ul>
 	  </li>
           <li class="nav-item {% if request.resolver_match.namespace == 'observations' %}active{% endif %}">
-              <a class="nav-link" href="{% url 'scheduling' %}" style="font-family: 'Montserrat', sans-serif;">Scheduling</a>
+              <a class="nav-link" href="{% url 'scheduling' %}" style="font-family: 'Montserrat', sans-serif; font-size:1.25vw;">Scheduling</a>
           </li>
           <li class="nav-item {% if request.resolver_match.namespace == 'dataproducts' %}active{% endif %}">
-              <a class="nav-link" href="{% url 'tom_dataproducts:list' %}" style="font-family: 'Montserrat', sans-serif;">Data</a>
+              <a class="nav-link" href="{% url 'tom_dataproducts:list' %}" style="font-family: 'Montserrat', sans-serif; font-size:1.25vw;">Data</a>
           </li>
 	  <li class="nav-item {% if request.resolver_match.namespace == 'floyds-inbox' %}active{% endif %}">
-	      <a class="nav-link" href="{% url 'floyds-inbox' %}" style="font-family: 'Montserrat', sans-serif;">Floyds Inbox</a>
+	      <a class="nav-link" href="{% url 'floyds-inbox' %}" style="font-family: 'Montserrat', sans-serif; font-size:1.25vw;">Floyds</a>
 	  </li>
           <li class="nav-item {% if 'user' in request.resolver_match.url_name %}active{% endif %}">
-            <a class="nav-link" href="{% url 'user-list' %}" style="font-family: 'Montserrat', sans-serif;">Users</a>
+            <a class="nav-link" href="{% url 'user-list' %}" style="font-family: 'Montserrat', sans-serif; font-size:1.25vw;">Users</a>
           </li>
 	  <li class="nav-item {% if request.resolver_match.namespace == 'custom_code' %}active{% endif %}">
-            <a class="nav-link" href="{% url 'custom_code:tns-targets' %}" style="font-family: 'Montserrat', sans-serif;">TNS Targets</a>
+            <a class="nav-link" href="{% url 'custom_code:tns-targets' %}" style="font-family: 'Montserrat', sans-serif; font-size:1.25vw;">TNS</a>
           </li>
 	  {% if user|has_gw_permissions %}
 	  <li class="nav-item {% if request.resolver_match.namespace == 'nonlocalizedevents' %}active{% endif %}">
-	    <a class="nav-link" href="/nonlocalizedevents/" style="font-family: 'Montserrat', sans-serif;">Non-Localized Events</a>
+	    <a class="nav-link" href="/nonlocalizedevents/" style="font-family: 'Montserrat', sans-serif; font-size:1.25vw;">Non-Localized Events</a>
 	  </li>
 	  {% endif %}
-	  <li class="nav-item" style="align-self: center;padding: 10px">
-	    <div class="target-search">
-	      <form action="{% url 'redirect' %}" method="get">
-                <input name="name" type="text" placeholder="Search by name or coords">
+	  <li class="nav-item" style="align-self: center;padding: 0px; width:10vw">
+	    <div class="target-search" style="width:10vw;">
+	      <form action="{% url 'redirect' %}" method="get" style="width:10vw">
+                <input name="name" type="text" placeholder="Search by name or coords" style="width:10vw; font-size:1.25vw">
               </form>
 	    </div>
 	  </li>
@@ -90,9 +90,9 @@
 	  </li>
           <li class="nav-item">
             {% if user.first_name or user.last_name %}
-            <a class="nav-link" href="{% url 'user-update' user.id %}">{{ user.first_name }} {{ user.last_name }}</a>
+            <a class="nav-link" href="{% url 'user-update' user.id %}" style="font-size:1.25vw;">{{ user.first_name }} {{ user.last_name }}</a>
             {% else %}
-            <a class="nav-link" href="{% url 'user-update' user.id %}">User {{ user.id }}</a>
+            <a class="nav-link" href="{% url 'user-update' user.id %}" style="font-size:1.25vw; vertical-align: middle; white-space: nowrap;;">User {{ user.id }}</a>
             {% endif %}
           </li>
           <li>
@@ -100,7 +100,7 @@
           </li>
         {% else %}
           <li class="nav-item">
-            <a class="btn btn-outline-success" title="logout" href="{% url 'login' %}">Login</a>
+            <a class="btn btn-outline-success" title="logout" href="{% url 'login' %}">>Login</a>
           </li>
         {% endif %}
       </div>

--- a/templates/tom_common/base.html
+++ b/templates/tom_common/base.html
@@ -69,7 +69,7 @@
           </li>
 	  {% if user|has_gw_permissions %}
 	  <li class="nav-item {% if request.resolver_match.namespace == 'nonlocalizedevents' %}active{% endif %}">
-	    <a class="nav-link" href="/nonlocalizedevents/" style="font-family: 'Montserrat', sans-serif; font-size:1.25vw;">Non-Localized Events</a>
+	    <a class="nav-link" href="/nonlocalizedevents/" style="font-family: 'Montserrat', sans-serif; font-size:1.25vw; white-space: nowrap">GW Events</a>
 	  </li>
 	  {% endif %}
 	  <li class="nav-item" style="align-self: center;padding: 0px; width:10vw">


### PR DESCRIPTION
# Navigation menu solution

This pull request represents a proposed solution to the issues with the navigation menu as currently implemented in `base.html`. Current behavior of the navigation menu looks something like this:

<img width="1265" alt="Screenshot 2023-08-13 at 9 08 53 PM" src="https://github.com/LCOGT/snex2/assets/14000301/724e1c7b-6678-45d9-978f-02e341887885"><img width="946" alt="Screenshot 2023-08-13 at 9 09 00 PM" src="https://github.com/LCOGT/snex2/assets/14000301/a6534c7d-4f64-4f53-96ad-0fabbf434faa">

The inconvenient elements are:
- The text is not properly scaled for the interface.
- The text wraps, causing issues navigating to particular menu items.
- The default text behavior can push menu items offscreen and make them inaccessible.
- The text is not conscious of window size.
- The search bar and usage bar take up the same space no matter the window size, meaning they can dominate on thin windows.

I've addressed these issues by making the navigation bar and its individual elements sensitive to the window size, using the `vw` keyword in `css`. I also chose shorter (but still intuitive) menu item names in order to improve the wrapping issue. I also applied this scaling effect to the usage bars and search bar, so they no longer dominate in thin windows. This change is implemented across all files where `base.html` is extended.

Here is the new top bar in action:

https://github.com/LCOGT/snex2/assets/14000301/d9172b1d-add3-480b-9edc-ee641696f208


# Import problem

A `django-4+` update produces the following `ImportError` in SNEx2 ([discussion](https://lcogt.slack.com/archives/CAM5F9FQR/p1691980794524869)): 

`ImportError: cannot import name 'KeyTextTransform' from 'django.contrib.postgres.fields.jsonb'`. 

This is due to an organizational change of how the module is called ([source](https://stackoverflow.com/questions/74100427/importerror-cannot-import-name-keytexttransform-from-django-contrib-postgres)) and requires a new import:

`from django.db.models.fields.json import KeyTextTransform`

I implemented and tested this fix and it addressed the issue, so I added it to this pull request as it was a minor change.

