### PR TITLE
Update settings.py with correct datetime format

### DIFF
--- a/snex2/settings.py
+++ b/snex2/settings.py
@@ -212,7 +212,7 @@ USE_L10N = False
 
 USE_TZ = True
 
-DATETIME_FORMAT = 'Y-m-d H:m:s'
+DATETIME_FORMAT = 'Y-m-d H:i:s'
 DATE_FORMAT = 'Y-m-d'
 
 


### PR DESCRIPTION
An [issue](https://github.com/TOMToolkit/tom_base/pull/778) has been discovered in the setup for tomtoolkit that mistakenly sets 
```Python
DATETIME_FORMAT = 'Y-m-d H:m:s'
```
in `settings.py`.
This code incorrectly used `m` (month) instead of `i` (minute) in the time format.

We are deploying a release to tomtoolkit that will correct this bug for future TOMs.

This change is needed for your TOM to behave correctly.