### PR TITLE
Fixing installation issues on Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.9-slim
 
 ENTRYPOINT ["./run.sh"]
 
@@ -7,6 +7,11 @@ RUN apt-get update && apt-get install -y git libpq-dev gcc gfortran mariadb-clie
 
 COPY . /snex2
 
+RUN pip3 install --upgrade pip
+
 RUN pip install numpy && pip install -r /snex2/requirements.txt
+
+RUN pip uninstall -y ligo.skymap 
+RUN pip install ligo.skymap
 
 WORKDIR /snex2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
             - ${SNEX2_DB_DATA_PATH}:/var/lib/postgresql/data
         ports:
             - 5435:5432/tcp
+        platform: linux/amd64
     snex2:
         image: lcogt/snex2:latest
         network_mode: bridge

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
 dataclasses
 tomtoolkit==2.12.0
 tom-scimma
-ligo.skymap==1.0.3
+ligo.skymap
 tom-nonlocalizedevents
 tom-alertstreams
+gevent==21.12.0
 gunicorn[gevent]
 django==4.2
 django-heroku


### PR DESCRIPTION
We address issues with installing SNEx2 on a variety of machines. We documented several issues that needed fixing, including:

- Dependency problems
- Github configuration issues
- Filesystem setup problems
- Dockerfile issues

We implement the following fixes to address these issues and more:

- Adding specific `gevent` version to `requirements.txt`
- Modifying `Dockerfile` environment version to `python3.9-slim`
- Upgrading `pip` via the `Dockerfile`
- Removing `ligo.skymap` from `requirements.txt`and reinstalling directly via the `Dockerfile`
- Adding specific platform request to `docker-compose.yml`

The installation procedure which takes advantage of these changes is available in the SNEx2 documentation (contact @crpellegrino for access).

Thanks to @gterreran , @cmccully , @crpellegrino  for help!