### PR TITLE
Fixed problem with time usage bars reporting incorrect values

### DIFF
--- a/custom_code/templates/custom_code/partials/time_usage_bars.html
+++ b/custom_code/templates/custom_code/partials/time_usage_bars.html
@@ -2,22 +2,22 @@
   <tr valign=center>
     <td><span style="color:#ececec; padding-right: 5px; padding-left: 5px;">{{ telescope }}:</span></td>
     <td>
-      <table cellpadding=0 cellspacing=0 border=0 style="width: 50px; height: 25px; table-layout: fixed;">
+      <table cellpadding=0 cellspacing=0 border=0 style="width: 100px; height: 25px; table-layout: fixed;">
         <tr style="height: 6px;" valign="bottom">
           <td style="width: {{ barwidth }}%;"</td>
           <td style="width: 10px; text-align: center; font-size: 8px;"><span style="color: #ececec;">&#9660;</span></td>
         </tr>
         <tr>
           <td colspan=3>
-            <table cellpadding=0 cellspacing=0 style="width: 50px; height: 13px; border: 1px solid #cccccc;">
+            <table cellpadding=0 cellspacing=0 style="width: 100px; height: 13px; border: 1px solid #cccccc;">
               <tr title="{{ tooltip }}">
               <td width="{{ usedbarwidth }}" bgcolor="{{ barcolor }}"></td>
-        	    <td bgcolor="#cccccc"></td>
+              <td bgcolor="#cccccc"></td>
               </tr>
             </table>
           </td>
         </tr>
-        <tr style="height: 6px; width: 50px;" valign="top">
+        <tr style="height: 6px;" valign="top">
           <td style="width: {{ barwidth }};"></td>
           <td valign="top" style="width: 5px; text-align: center;"><span style="line-height: 4px; color: #ececec;"></span></td>
         </tr>

--- a/custom_code/templates/custom_code/partials/time_usage_bars.html
+++ b/custom_code/templates/custom_code/partials/time_usage_bars.html
@@ -2,14 +2,14 @@
   <tr valign=center>
     <td><span style="color:#ececec; padding-right: 5px; padding-left: 5px;">{{ telescope }}:</span></td>
     <td>
-      <table cellpadding=0 cellspacing=0 border=0 style="width: 5vw; height: 25px; table-layout: fixed;">
+      <table cellpadding=0 cellspacing=0 border=0 style="width: 50px; height: 25px; table-layout: fixed;">
         <tr style="height: 6px;" valign="bottom">
           <td style="width: {{ barwidth }}%;"</td>
           <td style="width: 10px; text-align: center; font-size: 8px;"><span style="color: #ececec;">&#9660;</span></td>
         </tr>
         <tr>
           <td colspan=3>
-            <table cellpadding=0 cellspacing=0 style="width: 5vw; height: 13px; border: 1px solid #cccccc;">
+            <table cellpadding=0 cellspacing=0 style="width: 50px; height: 13px; border: 1px solid #cccccc;">
               <tr title="{{ tooltip }}">
               <td width="{{ usedbarwidth }}" bgcolor="{{ barcolor }}"></td>
         	    <td bgcolor="#cccccc"></td>
@@ -17,7 +17,7 @@
             </table>
           </td>
         </tr>
-        <tr style="height: 6px; width: 5vw;" valign="top">
+        <tr style="height: 6px; width: 50px;" valign="top">
           <td style="width: {{ barwidth }};"></td>
           <td valign="top" style="width: 5px; text-align: center;"><span style="line-height: 4px; color: #ececec;"></span></td>
         </tr>


### PR DESCRIPTION
The time usage bar at the top of the SNEx2 shows an incorrect fraction of time used depending on the size of the window:

![Screenshot 2024-03-25 at 3 57 47 PM](https://github.com/LCOGT/snex2/assets/14000301/d7ef75b8-26c9-4bed-9b02-d1c43f0c64a2)
![Screenshot 2024-03-25 at 3 58 29 PM](https://github.com/LCOGT/snex2/assets/14000301/9dc7e285-a5fb-4aed-a2e3-3b3a4982aaae)
_(these two views show the same usage but at different window scalings.)_

Implemented solution was to turn off scaling for the progress bar and make it a bit more economical space-wise. This will cut into some of the benefits of having an entirely dynamic top menu but works as a fix to ensure the time usage is reported correctly.