### PR TITLE
Triplets features bug fix - Allowing fits files to be f-packed

### DIFF
--- a/gw/templatetags/gw_tags.py
+++ b/gw/templatetags/gw_tags.py
@@ -91,9 +91,14 @@ def plot_triplets(triplet, galaxy, display_type):
     fig = go.Figure().set_subplots(1,3)
     
     for i, filetype in enumerate(['original', 'template', 'diff']):
-        hdu = fits.open(triplet[filetype]['filename'])
-        img = hdu[0].data
-        wcs = WCS(hdu[0].header)
+        img_file = triplet[filetype]['filename']
+        if img_file.endswith('fz'):
+            ext = 1
+        else:
+            ext = 0
+        hdu = fits.open(img_file)
+        img = hdu[ext].data
+        wcs = WCS(hdu[ext].header)
         hdu.close()
 
         if display_type == 'list':


### PR DESCRIPTION
All triplets were shown repeatedly under all galaxies. Now each galaxy will have only its own triplets shown under it.
Fixed also another bug related to f-packed images not being plotted, due to having the data in the second extension.
