### PR TITLE
Including hour angle limit in airmass plot

### DIFF
--- a/custom_code/templatetags/custom_code_tags.py
+++ b/custom_code/templatetags/custom_code_tags.py
@@ -139,7 +139,7 @@ def airmass_plot(context):
         'figure': visibility_graph
     }
 
-def get_24hr_airmass(target, interval, airmass_limit):
+def get_24hr_airmass(target, interval, airmass_limit, halimit=4.8):
 
     plot_data = []
     
@@ -197,10 +197,14 @@ def get_24hr_airmass(target, interval, airmass_limit):
             sun_alt = observer.altaz(time_range, fixed_sun).alt
             obj_airmass = observer.altaz(time_range, fixed_target).secz
 
+            ha = observer.target_hour_angle(time_range, fixed_target).value
+            ha[ha > 12] = 24 - ha[ha > 12]
+
             bad_indices = np.argwhere(
                 (obj_airmass >= airmass_limit) |
                 (obj_airmass <= 1) |
-                (sun_alt > -12*u.deg)  #between astro twilights
+                (sun_alt > -12*u.deg) | #between astro twilights
+                (ha > halimit)
             )
 
             obj_airmass = [np.nan if i in bad_indices else float(x)


### PR DESCRIPTION
This PR fixes misleading visibility info in SNEx2 airmass plots. These plots were incorrectly showing visibility at high airmasses. However, the LCO observation portal could not validate these requests due to constraints on the hour angle of these observations. The updated code better reproduces SNEx1 visibility plots by implementing an hour angle limit HA < 4.8. This should address some of the reported problems in TOM Toolkit [Issue 1017](https://github.com/TOMToolkit/tom_base/issues/1017). 

For example, attached are the airmass plots of the same target from SNEx2 with (top) and without (middle) these changes, as well as from SNEx1 (bottom). Adding the HA constraint better reproduces the SNEx1 visibility information (note the SNEx2 coordinates for TFN are still incorrect here, leading to slightly different airmass curves for this site). 

<img width="437" alt="image" src="https://github.com/user-attachments/assets/0aabf4cc-2dfa-421b-a144-35c35d259566">
<img width="437" alt="image" src="https://github.com/user-attachments/assets/13b45146-afda-4379-855e-2701394e7909">
<img width="639" alt="image" src="https://github.com/user-attachments/assets/113d79cf-1887-4f57-912c-6d5edc98e005">
