### PR TITLE
Bugfix/syncing targets race condition

### DIFF
--- a/custom_code/scripts/sync_databases.py
+++ b/custom_code/scripts/sync_databases.py
@@ -520,6 +520,10 @@ def update_target(action, db_address=_SNEX2_DB):
                             db_session.query(Targetname).filter(targetname_criteria).update({'name': t_name})
 
                         elif action=='insert':
+                            ### TODO: Check if target exists, and if not, add it here
+                            ### For some reason sometimes no target insertion is recorded in the db
+                            ### I think this happens if the target is added right as the syncing script runs
+                            ### (see targets 8556 and 8557 versus 8555)
                             existing_name = db_session.query(Targetname).filter(Targetname.name==t_name, Targetname.target_id==n_id).first()
                             if not existing_name:
                                 db_session.add(Targetname(name=t_name, target_id=n_id, created=datetime.datetime.utcnow(), modified=datetime.datetime.utcnow()))


### PR DESCRIPTION
This PR addresses a potential race condition when a new `Target` is added to SNEx1 while the `sync_databases.py` script is running. In the past this has thrown exceptions when the script attempts to sync a newly-created `TargetName` to a `Target` that is not yet in the SNEx2 database. 

To fix this issue, the script now checks whether the associated `Target` object exists in the SNEx2 database before ingesting a new `TargetName`. If not found, the script will create the `Target` before continuing to sync associated name and extra values. 

These changes should be ready to merge--let me know when they are and I'll keep an eye on the syncing process just to be sure everything is working as intended.