### PR TITLE
Sanitize target creation

### DIFF
--- a/custom_code/forms.py
+++ b/custom_code/forms.py
@@ -11,6 +11,8 @@ from django.db.models.functions import Lower
 from django.core.exceptions import ValidationError
 from django.contrib.auth.models import Group
 
+import re
+
 class CustomTargetCreateForm(SiderealTargetCreateForm):
 
     sciencetags = forms.ModelMultipleChoiceField(ScienceTags.objects.all().order_by(Lower('tag')), widget=forms.CheckboxSelectMultiple, label='Science Tags', required=False)
@@ -18,6 +20,11 @@ class CustomTargetCreateForm(SiderealTargetCreateForm):
     def clean(self):
         cleaned_data = super().clean()
         self.cleaned_data = cleaned_data
+
+        name = self.cleaned_data.get('name')
+        if re.match(r'^\d', name):  
+            raise ValidationError("Target name cannot start with a number.")
+        return name
 
 
     def __init__(self, *args, **kwargs):

--- a/custom_code/forms.py
+++ b/custom_code/forms.py
@@ -15,16 +15,23 @@ import re
 
 class CustomTargetCreateForm(SiderealTargetCreateForm):
 
+    def validate_target_name(target_name):
+        if target_name and target_name[0].isdigit():
+            raise ValidationError(f"Target name ({target_name}) cannot start with a number")
+
+
+
     sciencetags = forms.ModelMultipleChoiceField(ScienceTags.objects.all().order_by(Lower('tag')), widget=forms.CheckboxSelectMultiple, label='Science Tags', required=False)
+    name = forms.CharField(validators=[validate_target_name])
+
 
     def clean(self):
         cleaned_data = super().clean()
         self.cleaned_data = cleaned_data
 
         name = self.cleaned_data.get('name')
-        if re.match(r'^\d', name):  
-            raise ValidationError("Target name cannot start with a number.")
-        return name
+        # if re.match(r'^\d', name):  
+        #     raise ValidationError("Target name cannot start with a number.")
 
 
     def __init__(self, *args, **kwargs):

--- a/custom_code/views.py
+++ b/custom_code/views.py
@@ -275,10 +275,11 @@ class CustomTargetCreateView(TargetCreateView):
         return redirect(self.get_success_url())
     
     def form_valid(self, form):
+
         # First, create the targets in both dbs and nothing else
         with transaction.atomic():
             if form.is_valid():
-                
+
                 ### Check that there are no targets with the same name or coordinates
                 target_cone_search = Target.objects.filter(ra__gte=form.cleaned_data['ra']-4.0/3600.0, ra__lte=form.cleaned_data['ra']+4.0/3600.0, dec__gte=form.cleaned_data['dec']-4.0/3600.0, dec__lte=form.cleaned_data['dec']+4.0/3600.0)
                 if target_cone_search.count() > 0.0:
@@ -289,11 +290,13 @@ class CustomTargetCreateView(TargetCreateView):
 
                 name_lookup = form.cleaned_data['name'].replace('SN', '').replace('AT', '').replace(' ', '')
                 target_name_search = Target.objects.filter(Q(name__icontains=name_lookup) | Q(aliases__name__icontains=name_lookup)).distinct()
+
                 if target_name_search.count() > 0.0:
                     logger.info('Target with name {} already exists'.format(form.cleaned_data['name']))
                     form.errors['name'] = ['Target found with same name']
                     return super().form_invalid(form)
-                
+
+
                 groups = [g.name for g in form.cleaned_data['groups']]
                 self.object = form.save(form)
 


### PR DESCRIPTION
We would like to prevent users from adding targets with names that start with a number (which causes problems when snex2 attempts to query TNS). To this end, we have added validation to the `CustomTargetCreateForm`. This form inherits the `name` attribute from `SiderealTargetCreateForm`, so we have added a validation function `validate_target_name` which will check to see if the name starts with a number. 

We test this locally; it throws an error when a name is submitted that begins with a number (e.g., 2017aeee), but successfully creates the target page when the object name begins with a character (e.g., SN 2017aeee). 