### PR TITLE
Update TNS in requirements.txt to support TNS 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ tomtoolkit>=2.22.5
 tom-scimma
 tom-nonlocalizedevents==0.8.1
 tom-alertstreams
-tom_tns>=0.2.3
+tom_tns>=0.3.0
 gevent==21.12.0
 gunicorn[gevent]
 django==4.2


### PR DESCRIPTION
Updating TNS to 0.3.0 to use TNS 2.0. This is to fix the classification submission page to submit a TNS classification from the spectra page. Below is a screenshot of the issue, where the page is not loading correctly and unable to select a classification.

![image](https://github.com/user-attachments/assets/04f4b52b-3f88-482a-a162-70165a80d018)
