### PR TITLE
modified truncate_number to truncate_value_for_display

### DIFF
--- a/templates/tom_dataproducts/partials/photometry_datalist_for_target.html
+++ b/templates/tom_dataproducts/partials/photometry_datalist_for_target.html
@@ -40,7 +40,7 @@
                 <td>
                     <!-- prepend greater-than sign if this is a magnitude limit -->
                     {% if datum.limit %}>{% endif %}
-                    {{ datum.magnitude|truncate_number }}
+                    {{ datum.magnitude|truncate_value_for_display }}
                 </td>
                 {% if datum.error %}
                     <td>{{ datum.error|floatformat:4 }}</td>


### PR DESCRIPTION
Fixes error where cannot open object page, updates truncate_number to match  [tom_base](https://github.com/TOMToolkit/tom_base/blob/8efc6a353c7e2f2c235b528648c0e18fb7da76fe/tom_common/templatetags/tom_common_extras.py#L114)