### PR TITLE
feat(users): enable tom_registration in snex2 with backwards db syncing

### DIFF
--- a/custom_code/forms.py
+++ b/custom_code/forms.py
@@ -10,6 +10,14 @@ from django.conf import settings
 from django.db.models.functions import Lower
 from django.core.exceptions import ValidationError
 from django.contrib.auth.models import Group
+try:
+    from django.contrib.auth.forms import BaseUserCreationForm as UserCreationForm
+except ImportError:
+    from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.forms import UsernameField
+from django.contrib.auth.models import User, Group
+from django.db import transaction
+from crispy_forms.helper import FormHelper
 
 class CustomTargetCreateForm(SiderealTargetCreateForm):
 
@@ -59,6 +67,64 @@ class CustomTargetCreateForm(SiderealTargetCreateForm):
                 )
 
         return instance
+    
+class SNEx2UserCreationForm(UserCreationForm):
+    """
+    Form used for creation of new users and update of existing users.
+    """
+    email = forms.EmailField(required=True)
+    groups = forms.ModelMultipleChoiceField(Group.objects.all(),
+                                            required=False, widget=forms.CheckboxSelectMultiple)
+
+    class Meta:
+        model = User
+        fields = ('username', 'first_name', 'last_name', 'email', 'groups')
+        field_classes = {'username': UsernameField}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.helper = FormHelper()
+        self.form_tag = False
+
+    def save(self, commit=True):
+        # If any operations fail, we roll back
+        with transaction.atomic():
+            # Saving the MaterialRequisition first
+            user = super(forms.ModelForm, self).save(commit=False)
+
+            # Because this form is used for both create and update user, and the user can be updated without modifying
+            # the password, we check if the password field has been populated in order to set a new one.
+            if self.cleaned_data['password1']:
+                user.set_password(self.cleaned_data["password1"])
+            if commit:
+                # Saving the inline formsets
+                user.save()
+                self.save_m2m()
+
+            return user
+
+    # Also needs to be overridden in case any clean method are implemented
+    def clean(self):
+        super().clean()
+
+        return self.cleaned_data
+
+    # is_valid sets the cleaned_data attribute so we need to override that too
+    def is_valid(self):
+        is_valid = True
+        is_valid &= super().is_valid()
+
+        return is_valid
+
+    # In case you're using the form for updating, you need to do this too
+    # because nothing will be saved if you only update field in the inner formset
+    def has_changed(self):
+        has_changed = False
+
+        has_changed |= super().has_changed()
+
+        return has_changed
 
 
 class ReducerGroupWidget(forms.widgets.MultiWidget):

--- a/custom_code/hooks.py
+++ b/custom_code/hooks.py
@@ -945,7 +945,7 @@ def sync_users_with_snex1(user, created=False, old_username=''):
                 Users.username==old_username
             ).update(
                 {'name': user.username,
-                'pw': 'crypt$$'+user.password,
+                # 'pw': 'crypt$$'+user.password,
                 'firstname': user.first_name,
                 'lastname': user.last_name,
                 'email': user.email}

--- a/snex2/settings.py
+++ b/snex2/settings.py
@@ -387,24 +387,44 @@ TARGET_PERMISSIONS_ONLY = False
 # for example: OPEN_URLS = ['/', '/about']
 OPEN_URLS = ['/snex2/tnstargets/', '/pipeline-upload/photometry-upload/']
 
-HOOKS = {
-    'target_post_save': 'custom_code.hooks.target_post_save',
-    'observation_change_state': 'tom_common.hooks.observation_change_state',
-    'targetextra_post_save': 'custom_code.hooks.targetextra_post_save',
-    'targetname_post_save': 'custom_code.hooks.targetname_post_save',
-    'sync_observation_with_snex1': 'custom_code.hooks.sync_observation_with_snex1',
-    'sync_sequence_with_snex1': 'custom_code.hooks.sync_sequence_with_snex1',
-    'cancel_sequence_in_snex1': 'custom_code.hooks.cancel_sequence_in_snex1',
-    'update_reminder_in_snex1': 'custom_code.hooks.update_reminder_in_snex1',
-    'approve_sequence_in_snex1': 'custom_code.hooks.approve_sequence_in_snex1',
-    'find_images_from_snex1': 'custom_code.hooks.find_images_from_snex1',
-    'change_interest_in_snex1': 'custom_code.hooks.change_interest_in_snex1',
-    'sync_paper_with_snex1': 'custom_code.hooks.sync_paper_with_snex1',
-    'sync_comment_with_snex1': 'custom_code.hooks.sync_comment_with_snex1',
-    'cancel_gw_obs': 'gw.hooks.cancel_gw_obs',
-    'ingest_gw_galaxy_into_snex1': 'gw.hooks.ingest_gw_galaxy_into_snex1',
-    'sync_users_with_snex1': 'custom_code.hooks.sync_users_with_snex1',
-}
+if DEBUG:
+    HOOKS = {
+        'target_post_save': '',
+        'observation_change_state': '',
+        'targetextra_post_save': '',
+        'targetname_post_save': '',
+        'sync_observation_with_snex1': '',
+        'sync_sequence_with_snex1': '',
+        'cancel_sequence_in_snex1': '',
+        'update_reminder_in_snex1': '',
+        'approve_sequence_in_snex1': '',
+        'find_images_from_snex1': '',
+        'change_interest_in_snex1': '',
+        'sync_paper_with_snex1': '',
+        'sync_comment_with_snex1': '',
+        'cancel_gw_obs': '',
+        'ingest_gw_galaxy_into_snex1': '',
+        'sync_users_with_snex1': '',
+    }
+else:
+    HOOKS = {
+        'target_post_save': 'custom_code.hooks.target_post_save',
+        'observation_change_state': 'tom_common.hooks.observation_change_state',
+        'targetextra_post_save': 'custom_code.hooks.targetextra_post_save',
+        'targetname_post_save': 'custom_code.hooks.targetname_post_save',
+        'sync_observation_with_snex1': 'custom_code.hooks.sync_observation_with_snex1',
+        'sync_sequence_with_snex1': 'custom_code.hooks.sync_sequence_with_snex1',
+        'cancel_sequence_in_snex1': 'custom_code.hooks.cancel_sequence_in_snex1',
+        'update_reminder_in_snex1': 'custom_code.hooks.update_reminder_in_snex1',
+        'approve_sequence_in_snex1': 'custom_code.hooks.approve_sequence_in_snex1',
+        'find_images_from_snex1': 'custom_code.hooks.find_images_from_snex1',
+        'change_interest_in_snex1': 'custom_code.hooks.change_interest_in_snex1',
+        'sync_paper_with_snex1': 'custom_code.hooks.sync_paper_with_snex1',
+        'sync_comment_with_snex1': 'custom_code.hooks.sync_comment_with_snex1',
+        'cancel_gw_obs': 'gw.hooks.cancel_gw_obs',
+        'ingest_gw_galaxy_into_snex1': 'gw.hooks.ingest_gw_galaxy_into_snex1',
+        'sync_users_with_snex1': 'custom_code.hooks.sync_users_with_snex1',
+    }
 
 
 BROKERS = {
@@ -497,7 +517,7 @@ TOM_REGISTRATION = {
     'REGISTRATION_AUTHENTICATION_BACKEND': 'django.contrib.auth.backends.AllowAllUsersModelBackend',
     'REGISTRATION_REDIRECT_PATTERN': 'home',
     'REGISTRATION_STRATEGY': 'approval_required', 
-    'SEND_APPROVAL_EMAILS': False,  
+    'SEND_APPROVAL_EMAILS': True,  
     'APPROVAL_SUBJECT': f'Your {TOM_NAME} registration has been approved!',  # Optional subject line of approval email, (Default Shown)
     'APPROVAL_MESSAGE': f'Your {TOM_NAME} registration has been approved. You can log in <a href="mytom.com/login">here</a>.'  # Optional html-enabled body for approval email, (Default Shown)
 }
@@ -506,15 +526,15 @@ MANAGERS = [
     ('SNEx Secure', 'sne@lco.global')
 ]
 
+MANAGERS = [("SNe", "sne@lco.global")]
+EMAIL_SUBJECT_PREFIX = f'[{TOM_NAME}]'
 EMAIL_HOST = 'smtp.gmail.com'
-
 EMAIL_PORT = 587
-
 EMAIL_USE_TLS = True
-
+EMAIL_USE_SSL = False
 EMAIL_HOST_USER = 'snex@lco.global'
-
 EMAIL_HOST_PASSWORD = str(os.getenv('SNEX_EMAIL_PASSWORD', ''))
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 
 DATA_UPLOAD_MAX_MEMORY_SIZE = 7000000
 

--- a/snex2/urls.py
+++ b/snex2/urls.py
@@ -69,6 +69,7 @@ urlpatterns = [
     path('nonlocalizedevents/sequence/<int:id>/obs/', EventSequenceGalaxiesTripletView.as_view(), name='nonlocalizedevents-sequence-triplets'),
     path('nonlocalizedevents/galaxies/<int:id>/obs/', GWFollowupGalaxyTripletView.as_view(), name='nonlocalizedevents-galaxies-triplets'),
     path('', include('tom_registration.registration_flows.approval_required.urls', namespace='registration')),
+    path('snex2/accounts/approve/<int:pk>/', SNEx2UserApprovalView.as_view(), name="snex2-approve-user"),
     path('snex2/', include('custom_code.urls')),
     path('nonlocalizedevents/', include('tom_nonlocalizedevents.urls', namespace='nonlocalizedevents')),
     path('django_plotly_dash/', include('django_plotly_dash.urls')),

--- a/templates/tom_registration/approve_user.html
+++ b/templates/tom_registration/approve_user.html
@@ -1,0 +1,18 @@
+{% extends 'tom_common/base.html' %}
+{% load bootstrap4 static %}
+{% block title %}Approve user{% endblock %}
+{% block additional_css %}
+<link rel="stylesheet" href="{% static 'tom_targets/css/targets_snexclone.css' %}">
+{% endblock %}
+{% block content %}
+<form action="{% url 'snex2-approve-user' object.id %}" method="POST">
+{% csrf_token %}
+{% bootstrap_form form %}
+{% bootstrap_formset form.user_profile_formset %}
+{% buttons %}
+  <button type="submit" class="btn btn-primary">
+    Approve
+  </button>
+{% endbuttons %}
+</form>
+{% endblock %}

--- a/templates/tom_registration/partials/pending_users.html
+++ b/templates/tom_registration/partials/pending_users.html
@@ -1,0 +1,29 @@
+{% if request.user.is_superuser %}
+<h4>Pending Users</h4>
+<div class="row">
+    <div class="col-md-12">
+        <table class="table table-striped">
+          <thead>
+          <tr>
+            <th>Username</th>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Approve</th>
+            <th>Delete</th>
+        </tr>
+        </thead>
+        <tbody>
+            {% for user in users %}
+            <tr>
+                <td>{{ user.username }}</td>
+                <td>{{ user.first_name }} {{ user.last_name }}</td>
+                <td>{{ user.email }}</td>
+                <td><a href="{% url 'snex2-approve-user' user.id %}" class="btn btn-primary">Approve</a></td>
+                <td><a href="{% url 'user-delete' user.id %}" class="btn btn-danger">Delete</a></td>
+            </tr>
+              {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endif %}


### PR DESCRIPTION
### Description

This is the second in a series of PRs to integrate `tom_registration` into the SNEx2 workflow.

Link to first PR: #45 

This PR enables the `approval_required` registration flow in SNEx2, in which new users can request accounts from the SNEx2 frontend. These accounts are then "pending" until approved by a SNEx2 superuser. Once approved, the account is activated in SNEx2 and added to the SNEx1 database. 

To do so, the `tom_registration` `UserApprovalView` is overridden to add the db syncing hook. This PR also overrides the `UserCreationForm` form in `tom_base` to work around a bug in the previous PR which was preventing changes to users from saving. 

Other small changes:

- turns off db syncing hooks if `DEBUG=True` to allow for streamlined local testing
- sets up email notifications for managers and pending registered users (NOTE: the account authentication has to be completed internally, message me offline about that)

### Testing

1. Pull this branch and run a local instance of SNEx2
2. Before logging in, navigate to `/accounts/register/` and register a new account
3. Log in as your superuser account (make one with `python manage.py createsuperuser` from the terminal, if you didn't already) and navigate to `/users/`
4. Under "Pending Users", click "Approve" next to the newly-created user and "Approve" on the next page
5. Verify that the new user is added as under the "Active Users" header
6. Click on your name in the upper right corner and modify any of the fields
7. Click "Update" and verify the new values were saved properly