### PR TITLE
fix(targets): enable target pages to load in development [WIP]

### DIFF
--- a/custom_code/templatetags/custom_code_tags.py
+++ b/custom_code/templatetags/custom_code_tags.py
@@ -26,6 +26,7 @@ from astropy.coordinates import get_moon, get_sun, SkyCoord, AltAz
 import numpy as np
 import time
 import matplotlib.pyplot as plt
+import os
 
 from custom_code.models import *
 from custom_code.forms import CustomDataProductUploadForm, PapersForm, PhotSchedulingForm, SpecSchedulingForm, ReferenceStatusForm, ThumbnailForm
@@ -1622,7 +1623,7 @@ def image_slideshow(context, target):
         psfxs = [9999 for i in range(8)]
         psfys = [9999 for i in range(8)]
     
-    if not filenames:
+    if not filenames or not os.path.isdir('data/thumbs/'):
         return {'target': target,
                 'form': ThumbnailForm(initial={}, choices={'filenames': [('', 'No images found')]})}
     
@@ -1876,7 +1877,7 @@ def lightcurve_with_extras(target, user):
 def test_display_thumbnail(context, target):
     
     from os import listdir
-    from os.path import isfile, join
+    from os.path import isdir, isfile, join
     
     if not settings.DEBUG:
         #NOTE: Production
@@ -1900,7 +1901,7 @@ def test_display_thumbnail(context, target):
         psfxs = [9999 for i in range(8)]
         psfys = [9999 for i in range(8)]
 
-    if not filenames:
+    if not filenames or not isdir('data/thumbs/'):
         return {'top_images': [],
                 'bottom_images': []}
 


### PR DESCRIPTION
### Description

This PR makes small changes to allow target pages to load in development locally. The main adjustments are to thumbnail images plotted on the target detail page. In production, thumbnails are dynamically displayed by searching for the corresponding LCO images within the docker container volume. However, instances of SNEx2 run locally do not have access to these data, which leads to an error upon page load. 

This PR gets around this by checking if a thumbnail directory exists locally. If one does not exist, then SNEx2 skips the thumbnail display entirely. 

A future commit to this PR will enable dynamically downloading an archived LCO image to test the target page thumbnail display.

WIP and to be continued...