### PR TITLE
fix: modify User queries for comments to not use outdated username

### DIFF
--- a/custom_code/templatetags/custom_code_tags.py
+++ b/custom_code/templatetags/custom_code_tags.py
@@ -967,7 +967,7 @@ def observation_summary(context, target=None, time='previous'):
             ### Get any comments associated with this observation group
             content_type_id = ContentType.objects.get(model='observationgroup').id
             comments = Comment.objects.filter(object_pk=obsgroup.id, content_type_id=content_type_id).order_by('id')
-            comment_list = ['{}: {}'.format(User.objects.get(username=comment.user_name).first_name, comment.comment) for comment in comments]
+            comment_list = ['{}: {}'.format(comment.user.first_name, comment.comment) for comment in comments]
 
             parameters.append({'title': 'LCO Sequence'+title_suffix,
                                'summary': parameter_string,
@@ -1066,7 +1066,7 @@ def get_scheduling_form(observation, user_id, start, requested_str, case='notpen
     if not comment:
         comment_str = ''
     else:
-        comment_str = '{}: {}'.format(User.objects.get(username=comment.user_name).first_name, comment.comment)
+        comment_str = '{}: {}'.format(comment.user.first_name, comment.comment)
     
     parameter = observation.parameters
     if parameter.get('observation_type', '') == 'IMAGING':
@@ -1342,7 +1342,7 @@ def dash_spectra_page(context, target):
 
                 content_type_id = ContentType.objects.get(model='reduceddatum').id
                 comments = Comment.objects.filter(object_pk=spectrum.id, content_type_id=content_type_id).order_by('id')
-                comment_list = ['{}: {}'.format(User.objects.get(username=comment.user_name).first_name, comment.comment) for comment in comments]
+                comment_list = ['{}: {}'.format(comment.user.first_name, comment.comment) for comment in comments]
                 spec_extras['comments'] = comment_list
             
             else:
@@ -1360,7 +1360,7 @@ def dash_spectra_page(context, target):
 
                 content_type_id = ContentType.objects.get(model='reduceddatum').id
                 comments = Comment.objects.filter(object_pk=spectrum.id, content_type_id=content_type_id).order_by('id')
-                comment_list = ['{}: {}'.format(User.objects.get(username=comment.user_name).first_name, comment.comment) for comment in comments]
+                comment_list = ['{}: {}'.format(comment.user.first_name, comment.comment) for comment in comments]
                 spec_extras['comments'] = comment_list
         else:
             spec_extras = {}


### PR DESCRIPTION
### Description

Modifies `User` lookups when displaying comments on target overview pages, spectra display pages, and scheduling page. This bug was caused by recent changes enabling users to update their usernames. The updated usernames are not propagated to the `django_comments` table, and the code was attempting to look up users on their outdated usernames, throwing an error. This PR now gets user info by the `User` association on the `django_comments` table itself, bypassing an extra lookup on the `User` table.

### Testing

1. In your local SNEx2 instance, on the master branch, create an observation sequence for a target and add a comment to the sequence before submitting it
2. Click on your name in the top right corner and change your username
3. Reload the target page and confirm an error is thrown
4. Checkout this branch, reload the page, and confirm everything loads and the sequence displays correctly under the "Observations" tab