### PR TITLE
Add a download button to the image slideshow page

### DIFF
--- a/custom_code/templates/custom_code/image_slideshow.html
+++ b/custom_code/templates/custom_code/image_slideshow.html
@@ -24,6 +24,12 @@
       <img id="form-img" style="width: 70%; height: 70%; margin-left: 5px; margin-top: 5px;" src="data:image/png;base64,{{ thumb }}" alt="img">
       <button class="btn" id="next-img" style="font-size: 20px; display: none;" onclick="nextImg()">Next &raquo;</button>
     </div>
+    <div class="row justify-content-center mt-3">
+      <form method="get" action="{% url 'download-fits' %}">
+      <input type="hidden" id="download-filename" name="filename" value="">
+      <button type="submit" class="btn btn-primary" style="width: 200px;" onclick="downloadFile()">Download Fits</button>
+      </form>
+    </div>
   </div>
   <div class="col-md-2">
     <form>
@@ -63,7 +69,7 @@
     var zoomVal = document.getElementById("id_zoom").value;
     var sigmaVal = document.getElementById("id_sigma").value;
     var filenameVal = document.getElementById("id_filenames").value;
-
+    document.getElementById("download-filename").value = filenameVal;
     $.ajax({
       url: '{% url "make-thumbnail" %}',
       data: {'zoom': zoomVal,
@@ -87,6 +93,7 @@
     if (select.selectedIndex === select.options.length - 2) {
       select.selectedIndex++;
       document.getElementById("previous-img").style.display = "none";
+      document.getElementById("next-img").style.display = "block";
     } else {
       select.selectedIndex++;
       document.getElementById("next-img").style.display = "block";
@@ -98,10 +105,41 @@
     if (select.selectedIndex === 1) {
       select.selectedIndex--;
       document.getElementById("next-img").style.display = "none";
+      document.getElementById("previous-img").style.display = "block";
     } else {
       select.selectedIndex--;
       document.getElementById("previous-img").style.display = "block";
     }
     makeThumbnail();
   };
+  async function downloadFile() {
+    const downloadButton = document.querySelector("button[onclick='downloadFile()']");
+    const filenameVal = document.getElementById("download-filename").value;
+
+    const fileData = JSON.parse(filenameVal);
+    const finalFilename = fileData.filename + '.fits';
+
+    const originalButtonText = downloadButton.innerHTML;
+    downloadButton.innerHTML = "Downloading...";
+    downloadButton.disabled = true;
+
+    const response = await fetch(`{% url 'download-fits' %}?filename=${encodeURIComponent(filenameVal)}`);
+    const blob = await response.blob();
+    
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.style.display = 'none';
+    a.href = url;
+    a.download = finalFilename; 
+    document.body.appendChild(a);
+    a.click();
+    window.URL.revokeObjectURL(url);
+    document.body.removeChild(a);
+
+    downloadButton.innerHTML = originalButtonText;
+    downloadButton.disabled = false;
+  }
+  document.addEventListener("DOMContentLoaded", function() {
+    makeThumbnail();
+  });
 </script>

--- a/custom_code/views.py
+++ b/custom_code/views.py
@@ -4,7 +4,7 @@ from django.core.files.base import ContentFile
 from django.db import transaction
 from django.db.models import Q, DateTimeField, FloatField, F, ExpressionWrapper
 from django.db.models.functions import Cast
-from django.http import HttpResponse, JsonResponse, HttpResponseRedirect
+from django.http import HttpResponse, JsonResponse, HttpResponseRedirect, FileResponse
 from django.views.generic.base import TemplateView, RedirectView
 from django.views.generic.list import ListView
 from django.views.generic.edit import FormView
@@ -33,6 +33,7 @@ from django.db.models.fields.json import KeyTextTransform
 from astropy.coordinates import SkyCoord
 from astropy import units as u
 from astropy.time import Time
+import time
 from datetime import datetime, date, timedelta
 import json
 from io import StringIO
@@ -44,7 +45,7 @@ from custom_code.templatetags.custom_code_tags import airmass_collapse, lightcur
 from custom_code.hooks import _get_tns_params, _return_session, get_unreduced_spectra, get_standards_from_snex1
 from custom_code.thumbnails import make_thumb
 
-from .forms import CustomTargetCreateForm, CustomDataProductUploadForm, PapersForm, ReferenceStatusForm
+from .forms import CustomTargetCreateForm, CustomDataProductUploadForm, PapersForm, ReferenceStatusForm,ThumbnailForm
 from tom_targets.views import TargetCreateView
 from tom_common.hooks import run_hook
 
@@ -62,8 +63,9 @@ from tom_observations.facilities.lco import LCOSettings
 from tom_observations.views import ObservationCreateView, ObservationListView
 from tom_registration.registration_flows.approval_required.views import UserApprovalView
 import base64
-
+import requests
 import logging
+from io import BytesIO
 
 logger = logging.getLogger(__name__)
 
@@ -1711,7 +1713,23 @@ def make_thumbnail_view(request):
 
     return HttpResponse(json.dumps(content_response), content_type='application/json')
 
-
+def download_fits_view(request):
+    token = settings.FACILITIES['LCO']['api_key']
+    url = settings.FACILITIES['LCO']['archive_url']
+    t1 = time.time()
+    object_basename = json.loads(request.GET.get('filename'))['filename']
+    t2 = time.time()
+    print(f't2-t1: {t2-t1:0.2e}')
+    results = requests.get(url,
+                           headers={'Authorization': f'Token {token}'}, 
+                           params={'basename_exact': object_basename, 'include_related_frames': False}).json()["results"]
+    t3 = time.time()
+    print(f't3-t2: {t3-t2:0.2f}')
+    data = requests.get(results[0]["url"]).content
+    t4 = time.time()
+    print(f't4-t3: {t4-t3:0.2f}')
+    return FileResponse(BytesIO(data),filename=object_basename+'.fits', as_attachment=True)
+    
 class InterestingTargetsView(ListView):
 
     template_name = 'custom_code/interesting_targets.html'

--- a/snex2/settings.py
+++ b/snex2/settings.py
@@ -280,6 +280,7 @@ TARGET_TYPE = 'SIDEREAL'
 FACILITIES = {
     'LCO': {
         'portal_url': 'https://observe.lco.global',
+        'archive_url': 'https://archive-api.lco.global/frames/',
         'api_key': os.environ.get('LCO_APIKEY', 'setyourapikey!'),
     },
     'SOAR': {

--- a/snex2/urls.py
+++ b/snex2/urls.py
@@ -54,6 +54,7 @@ urlpatterns = [
     path('query-swift-observations/', query_swift_observations_view, name='query-swift-observations'),
     path('load-lc/', load_lightcurve_view, name='load-lc'),
     path('make-thumbnail/', make_thumbnail_view, name='make-thumbnail'),
+    path('download-fits/', download_fits_view, name='download-fits'),
     path('interesting-targets/', InterestingTargetsView.as_view(), name='interesting-targets'),
     path('load-spectra-page/', async_spectra_page_view, name='load-spectra-page'),
     path('load-upcoming-reminders/', async_scheduling_page_view, name='load-upcoming-reminders'),


### PR DESCRIPTION
Added a download button to the object page under "Images" as shown below.
<img width="1137" height="634" alt="Screenshot 2025-07-28 at 4 02 14 PM" src="https://github.com/user-attachments/assets/32fe9649-0cbe-4691-86f7-606f3127b97f" />

When clicked, the Download Fits button will change to "Downloading. . ." and not be clickable. Once the download is complete (should be within 10 seconds), the button will switch back through an async function in `image_slideshow.html`. The download functionality is by using the filename selected from the dropdown (default on opening the page is the most recent image) and querying the LCO archive and downloading the image. This functionality in `download_fits_view` within `views.py`.

The archive url is also added to the `settings.py` as well.