### PR TITLE
remove 'id' from dash call

### DIFF
--- a/custom_code/dash_apps/spectra.py
+++ b/custom_code/dash_apps/spectra.py
@@ -19,7 +19,7 @@ import matplotlib.pyplot as plt
 
 external_stylesheets = [dbc.themes.BOOTSTRAP]
 
-app = DjangoDash(name='Spectra', id='target_id', add_bootstrap_links=True, suppress_callback_exceptions=True)   # replaces dash.Dash
+app = DjangoDash(name='Spectra', add_bootstrap_links=True, suppress_callback_exceptions=True)   # replaces dash.Dash
 app.css.append_css({'external_url': static('custom_code/css/dash.css')})
 
 params = [

--- a/custom_code/dash_apps/spectra_individual.py
+++ b/custom_code/dash_apps/spectra_individual.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 external_stylesheets = [dbc.themes.BOOTSTRAP]
 
-app = DjangoDash(name='Spectra_Individual', id='spectrum_id', add_bootstrap_links=True, suppress_callback_exceptions=True)   # replaces dash.Dash
+app = DjangoDash(name='Spectra_Individual', add_bootstrap_links=True, suppress_callback_exceptions=True)   # replaces dash.Dash
 app.css.append_css({'external_url': static('custom_code/css/dash.css')})
 
 params = [


### PR DESCRIPTION
Update spectra plotting DjangoDash calls to no longer include id. Test on a working installation by making fresh python 3.11 environment and running the installation and run server commands:

```
conda install mysql postgresql
uv pip install '.[dev]'
python manage.py runserver 8889
```

Then navigate to a target page successfully.