### PR TITLE
added an error raise for when no filenames are found

### DIFF
--- a/custom_code/hooks.py
+++ b/custom_code/hooks.py
@@ -679,7 +679,9 @@ def find_images_from_snex1(targetid, allimages=False):
         else:
             query = db_session.query(Photlco).filter(and_(Photlco.targetid==targetid, Photlco.filetype==1)).order_by(Photlco.id.desc())
         filepaths = [q.filepath.replace(settings.LSC_DIR, '').replace('/supernova/data/', '') for q in query]
-        print(filepaths)
+        logger.info('filepaths for target {} {}'.format(targetid,filepaths))
+        if len(filepaths)==0:
+            raise IndexError(f"No images found for target {targetid}") 
         filenames = [q.filename.replace('.fits', '') for q in query]
         dates = [date.strftime(q.dateobs, '%m/%d/%Y') for q in query]
         teles = [q.telescope[:3] for q in query]


### PR DESCRIPTION
Addresses issue #89, raises an IndexError when filepaths list is empty to trigger the except and display no images on the target page.