### PR TITLE
fix scheduling page class and z not showing

### DIFF
--- a/custom_code/templates/custom_code/scheduling_list_with_form.html
+++ b/custom_code/templates/custom_code/scheduling_list_with_form.html
@@ -69,12 +69,10 @@ input[type=number]::-webkit-outer-spin-button {
       <td><a class="btn btn-success" href="{% url 'custom_code:observationgroup-detail' parameter.obsgroup_id %}" target="_blank">Details</a></td>
       <td><a href="{% url 'tom_targets:detail' parameter.target.id %}" title="{{ parameter.target.id }}" target="_blank">{{ parameter.names|join:", " }}</a></td>
       <td>
-      {% with parameter.target as target %}
-          {{ target.classification }}
+      {{ parameter.classification }}
       </td>
       <td>
-	      {{ target.redshift|strip_trailing_zeros }}
-      {% endwith %}
+	    {{ parameter.redshift|strip_trailing_zeros }}
       </td>
       <td>
 	<div class="row">{{ parameter.facility }}</div>

--- a/custom_code/templatetags/custom_code_tags.py
+++ b/custom_code/templatetags/custom_code_tags.py
@@ -1047,7 +1047,7 @@ def get_scheduling_form(observation, user_id, start, requested_str, case='notpen
     parameters = []
     facility = observation.facility 
     obsgroup = observation.observationgroup_set.first()
-    target = observation.target
+    target = Target.objects.get(pk=observation.target.id)
     target_names = smart_name_list(observation.target)
 
     content_type_id = ContentType.objects.get(model='observationgroup').id
@@ -1120,6 +1120,8 @@ def get_scheduling_form(observation, user_id, start, requested_str, case='notpen
         parameters.append({'observation_id': observation.id,
                            'obsgroup_id': obsgroup.id,
                            'target': target,
+                           'classification': target.classification,
+                           'redshift': target.redshift,
                            'names': target_names,
                            'facility': facility,
                            'proposal': parameter.get('proposal', ''),


### PR DESCRIPTION
Fixed the classification and redshift not showing up on SNEx2 scheduling page. This was due to the scheduling view using `BaseTarget` instead of `Target`.