### PR TITLE
fix username typo

### DIFF
--- a/custom_code/hooks.py
+++ b/custom_code/hooks.py
@@ -946,7 +946,7 @@ def sync_users_with_snex1(user, created=False, old_username=''):
 
         else:
             db_session.query(Users).filter(
-                Users.username==old_username
+                Users.name==old_username
             ).update(
                 {'name': user.username,
                 # 'pw': 'crypt$$'+user.password,


### PR DESCRIPTION
Typo in the snex1 table for username, creates server 500 error