### PR TITLE
Add gw listener to deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,68 +80,18 @@ services:
             - ${SNEX_FLOYDS_PATH}:/snex2/data/floyds/
             - ${SNEX_FLOYDS_WEB_PATH}:/snex2/data/WEB/floyds/
             - ${SNEX_EXTDATA}:/snex2/data/fits/extdata/
-    # snex2-dev:
-    #     image: snex2-dev:latest
-    #     network_mode: bridge
-    #     links:
-    #         - "snex2-db:snex2-db"
-    #     ports:
-    #         - 8890:8080
-    #     restart: "always"
-    #     mem_limit: "12g"
-    #     logging:
-    #         options:
-    #             max-file: "3"
-    #             max-size: "10m"
-    #     environment:
-    #         - DB_NAME=snex2-dev
-    #         - SNEX2_DB_HOST=snex2-db
-    #         - SNEX2_DB_PORT=5432
-    #         - SNEX2_USER=${SNEX2_USER}
-    #         - SNEX2_DB_USER=${SNEX2_DB_USER}
-    #         - SNEX2_DB_PASSWORD=${SNEX2_DB_PASSWORD}
-    #         - SNEX1_DB_USER=${SNEX1_DB_USER}
-    #         - SNEX1_DB_PASSWORD=${SNEX1_DB_PASSWORD}
-    #         - SNEX2_DB_BACKEND=postgres
-    #         - LCO_APIKEY=${SNEX2_LCO_APIKEY}
-    #         - SNEXBOT_APIKEY=${SNEX2_SNEXBOT_APIKEY}
-    #         - AWS_ACCESS_KEY_ID=${SNEX2_AWS_ACCESS_KEY_ID}
-    #         - AWS_S3_REGION_NAME=${SNEX2_AWS_REGION_NAME}
-    #         - AWS_SECRET_ACCESS_KEY=${SNEX2_AWS_SECRET_ACCESS_KEY}
-    #         - AWS_STORAGE_BUCKET_NAME=${SNEX2_AWS_STORAGE_BUCKET_NAME}
-    #         - TWITTER_APIKEY=${SNEX2_TWITTER_APIKEY}
-    #         - TWITTER_SECRET=${SNEX2_TWITTER_SECRET}
-    #         - TWITTER_ACCESSTOKEN=${SNEX2_TWITTER_ACCESSTOKEN}
-    #         - TWITTER_ACCESSSECRET=${SNEX2_TWITTER_ACCESSSECRET}
-    #         - GEMINI_EMAIL=${SNEX2_GEMINI_EMAIL}
-    #         - GEMINI_SOUTH_PROGRAMID=${SNEX2_GEMINI_SOUTH_PROGRAMID}
-    #         - GEMINI_SOUTH_PASSWORD=${SNEX2_GEMINI_SOUTH_PASSWORD}
-    #         - GEMINI_SOUTH_SERVER=${SNEX2_GEMINI_SOUTH_SERVER}
-    #         - GEMINI_NORTH_PROGRAMID=${SNEX2_GEMINI_NORTH_PROGRAMID}
-    #         - GEMINI_NORTH_PASSWORD=${SNEX2_GEMINI_NORTH_PASSWORD}
-    #         - GEMINI_NORTH_SERVER=${SNEX2_GEMINI_NORTH_SERVER}
-    #         - SNEX_EMAIL_PASSWORD=${SNEX_EMAIL_PASSWORD}
-    #         - TNS_APIKEY=${TNS_APIKEY}
-    #         - TNS_APIID=${TNS_APIID}
-    #         - SWIFT_USERNAME=${SWIFT_USERNAME}
-    #         - SWIFT_SECRET=${SWIFT_SECRET}
-    #         - LASAIR_IRIS_TOKEN=${LASAIR_IRIS_TOKEN}
-    #         - SCIMMA_AUTH_USERNAME=${SCIMMA_AUTH_USERNAME}
-    #         - SCIMMA_AUTH_PASSWORD=${SCIMMA_AUTH_PASSWORD}
-    #         - GCN_CLASSIC_CLIENT_ID=${GCN_CLASSIC_CLIENT_ID}
-    #         - GCN_CLASSIC_CLIENT_SECRET=${GCN_CLASSIC_CLIENT_SECRET}
-    #         - CREDENTIAL_USERNAME=${CREDENTIAL_USERNAME}
-    #         - CREDENTIAL_PASSWORD=${CREDENTIAL_PASSWORD}
-    #         - TM_TOKEN=${TM_TOKEN}
-    #         - HERMES_BASE_URL=${HERMES_BASE_URL}
-    #         - HERMES_API_KEY=${HERMES_API_KEY}
-    #     volumes:
-    #         - ${SNEX_THUMBNAIL_PATH}:/snex2/data/thumbs/
-    #         - ${SNEX_FITS_PATH}:/snex2/data/fits/
-    #         - ${SNEX_0m4_FITS_PATH}:/snex2/data/fits/0m4/
-    #         - ${SNEX_2m_FITS_PATH}:/snex2/data/fits/fts/
-    #         - ${SNEX_MUSCAT_FITS_PATH}:/snex2/data/fits/2m0a/
-    #         - ${SNEX_GW_FITS_PATH}:/snex2/data/fits/gw/
-    #         - ${SNEX_FLOYDS_PATH}:/snex2/data/floyds/
-    #         - ${SNEX_FLOYDS_WEB_PATH}:/snex2/data/WEB/floyds/
-    #         - ${SNEX_EXTDATA}:/snex2/data/fits/extdata/
+    snex2-gw-listener:
+        image: lcogt/snex2:latest
+        container_name: snex2-snex2-gw-listener-1
+        network_mode: bridge
+        links:
+            - "snex2:snex2"
+        ports:
+            - 8888:8080
+        restart: "always"
+        entrypoint: [ "bash", "-c", "python manage.py readstreams"]
+        environment:
+            - SCIMMA_AUTH_USERNAME=${SCIMMA_AUTH_USERNAME}
+            - SCIMMA_AUTH_PASSWORD=${SCIMMA_AUTH_PASSWORD}
+            - GCN_CLASSIC_CLIENT_ID=${GCN_CLASSIC_CLIENT_ID}
+            - GCN_CLASSIC_CLIENT_SECRET=${GCN_CLASSIC_CLIENT_SECRET}


### PR DESCRIPTION
### Description

Adds a container to the `docker-compose` to run the gw listener as part of the deployment. This ensures that the listener runs each time SNEx2 is restarted. 

### Testing

1. For testing in the `dev-deploy` environment, copy the `snex2-gw-listener` container from this branch's `docker-compose` into your local `docker-compose` (you may have to adjust the image name to the dev image)
2. Run `docker-compose ... down` and `docker-compose ... up` and check the logs to make sure the listener is running in its container
3. Note that the actual ingestion is currently broken and will be fixed in a separate PR