### PR TITLE
changed order of user list

### DIFF
--- a/templates/auth/user_list.html
+++ b/templates/auth/user_list.html
@@ -10,9 +10,9 @@
     <h3>User Management</h3>
   </div>
 </nav>
-{% group_list %}
-</hr>
 {% pending_users %}
-<hr/>
+</hr>
 {% user_list %}
+<hr/>
+{% group_list %}
 {% endblock %}


### PR DESCRIPTION
Now when a superuser, Pending Users show up at the top, then Active Users, then Groups.