### PR TITLE
Fix update user

### DIFF
--- a/custom_code/scripts/sync_databases.py
+++ b/custom_code/scripts/sync_databases.py
@@ -753,7 +753,6 @@ def update_users(action, db_address=_SNEX2_DB):
                     )
 
                     if user:
-                        logger.info(f'User already exists, updating: {user.username}')
                         user.password = 'crypt$$' + user_row.pw
                         user.first_name = user_row.firstname
                         user.last_name = user_row.lastname


### PR DESCRIPTION
Fixing issue where update_user fails when a new user is registered on snex2, checks for a user existing and updates any changes.