### PR TITLE
removed obs tab from the mutation observer monitoring

### DIFF
--- a/templates/tom_targets/target_detail.html
+++ b/templates/tom_targets/target_detail.html
@@ -660,6 +660,12 @@ function setupDashErrorMonitoring() {
       return;
     }
     
+    // Skip monitoring for iframes inside the observations tab
+    if ($iframe.closest('#observations').length > 0) {
+      console.log('Skipping Dash monitoring for observations tab iframe');
+      return;
+    }
+    
     // Generate a unique ID for this iframe
     var iframeId = $iframe.attr('id') || ('dash-iframe-' + Math.random().toString(36).substr(2, 9));
     if (!$iframe.attr('id')) {


### PR DESCRIPTION
We're investigating an issue where the observation tab is reloading itself and not storing inputted user data properly. Until we can figure that out I've removed the observation tab from the `MutationObserver` monitoring. Tested on a local snexdev environment (3 objects). 