### PR TITLE
Adding capability for manual upload of BANZAI-FLOYDS reduced spectra

### DIFF
--- a/custom_code/processors/spectroscopy_processor.py
+++ b/custom_code/processors/spectroscopy_processor.py
@@ -11,10 +11,6 @@ from astropy import units
 from specutils import Spectrum1D
 from datetime import datetime
 import numpy as np
-import logging
-
-
-logger = logging.getLogger(__name__)
 
 class SpecProcessor(SpectroscopyProcessor):
 
@@ -55,9 +51,7 @@ class SpecProcessor(SpectroscopyProcessor):
 
     def _process_spectrum_from_fits(self, data_product, rd_extras):
 
-        # update to work with banzai floyds - look at PR
-
-        data_aws = default_storage.open(data_product.data.name, 'rb') # data product for spectrum
+        data_aws = default_storage.open(data_product.data.name, 'rb')
                 
         hlist = fits.open(data_aws.open())
         banzai_reduc = 'SPECTRUM' in hlist
@@ -75,7 +69,6 @@ class SpecProcessor(SpectroscopyProcessor):
             if facility.is_fits_facility(header):
                 flux_constant = facility.get_flux_constant()
                 if rd_extras.get('date_obs'):
-                    #logger.info(f"rd_extras date obs: {rd_extras['date_obs']}")
                     date_obs = datetime.fromisoformat(str(rd_extras['date_obs']).replace(' ', 'T'))
                 else:
                     date_obs = facility.get_date_obs_from_fits_header(header)
@@ -83,14 +76,11 @@ class SpecProcessor(SpectroscopyProcessor):
         else:
             flux_constant = self.DEFAULT_FLUX_CONSTANT
             if rd_extras.get('date_obs'):
-                #logger.info(f"rd_extras date obs in else statement: {rd_extras['date_obs']}")
                 date_obs = datetime.fromisoformat(str(rd_extras['date_obs']).replace(' ', 'T'))
             else:
                 date_obs = Time(datetime.now()).to_datetime
         
-        logger.info(f"rd_extra key and values: {rd_extras.keys()} :{rd_extras.values()}")
         for keyword, possibles in self.field_keywords.items():
-            logger.info(f"keyword: {keyword}")
 
             # Check if the keyword or any possible is already in rd_extras with a non-empty value; if so, skip this keyword
             if (keyword in rd_extras and rd_extras.get(keyword, '')) or any(possible in rd_extras and rd_extras.get(possible, '') for possible in possibles):
@@ -98,17 +88,13 @@ class SpecProcessor(SpectroscopyProcessor):
 
             # If none are in rd_extras, check the header for each possible
             for possible in possibles:
-                logger.info(f"possible {possible} is not in rd_extras")
             
                 if possible in header:
         
                     value = header[possible]
-                    logger.info(f"")
                     if keyword == "date_obs" and not rd_extras.get('date_obs'):
-                        logger.info(f"line 112 date obs not in keyword or rd_extras")
                         k_lower = possible.lower()
                         if "mjd" in k_lower:
-                            logger.info(f"going through mjd in header")
                             value = Time(float(value), format="mjd").to_datetime()
                         elif "jd" in k_lower:
                             value = Time(float(value), format="jd").to_datetime()
@@ -116,7 +102,6 @@ class SpecProcessor(SpectroscopyProcessor):
                             value = datetime.fromisoformat(str(value).replace(' ', 'T'))
                         date_obs = value
                     rd_extras[keyword] = value
-                    logger.info(f"keyword:value : {keyword}:{value}")
                     break
 
         dim = len(flux.shape)
@@ -132,14 +117,12 @@ class SpecProcessor(SpectroscopyProcessor):
             wcs = WCS(header=header, naxis=1)
             spectrum = Spectrum1D(flux=flux, wcs=wcs)
         else:
-            logger.info(f"Checking for nans in flux: {np.isnan(flux).sum()}")
-
             # Convert flux and wavelength to arrays and skip NaNs
             flux_values = np.array(flux, dtype=float)
             wav_values = np.array(wav, dtype=float)
             valid_mask = ~np.isnan(flux_values)  # keep only non-NaN flux points
             spectrum = Spectrum1D(flux=flux_values[valid_mask] * flux_constant, spectral_axis=wav_values[valid_mask] * units.Angstrom)
-            #spectrum = Spectrum1D(flux=flux, spectral_axis=np.array(wav) * units.Angstrom)
+            
         rd_extras.pop('date_obs')
 
         return spectrum, date_obs, rd_extras

--- a/custom_code/processors/spectroscopy_processor.py
+++ b/custom_code/processors/spectroscopy_processor.py
@@ -11,6 +11,10 @@ from astropy import units
 from specutils import Spectrum1D
 from datetime import datetime
 import numpy as np
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 class SpecProcessor(SpectroscopyProcessor):
 
@@ -25,7 +29,7 @@ class SpecProcessor(SpectroscopyProcessor):
                      "utshut", "utc-obs", "utc"],        
         "telescope": ["telescope", "telescop", "observat"],
         "instrument": ["instrument", "instrume"],
-        "slit": ["slit", "aperture", "slitname"],
+        "slit": ["APERWID", "slit", "aperture", "slitname"],
         "exptime": ["exptime", "exposure", "itot"],
         "airmass": ["airmass", "am", "tcs_am"],
         "grism": ["grism"],
@@ -51,39 +55,70 @@ class SpecProcessor(SpectroscopyProcessor):
 
     def _process_spectrum_from_fits(self, data_product, rd_extras):
 
-        data_aws = default_storage.open(data_product.data.name, 'rb')
+        # update to work with banzai floyds - look at PR
+
+        data_aws = default_storage.open(data_product.data.name, 'rb') # data product for spectrum
                 
-        flux, header = fits.getdata(data_aws.open(), header=True)
+        hlist = fits.open(data_aws.open())
+        banzai_reduc = 'SPECTRUM' in hlist
+        if banzai_reduc:
+                header = hlist['PRIMARY'].header
+                spec_table = hlist['SPECTRUM'].data
+                flux = spec_table['flux']
+                wav = spec_table['wavelength']
+        else:
+            flux, header = fits.getdata(data_aws.open(), header=True)
+
 
         for facility_class in get_service_classes():
             facility = get_service_class(facility_class)()
             if facility.is_fits_facility(header):
                 flux_constant = facility.get_flux_constant()
-                date_obs = facility.get_date_obs_from_fits_header(header)
+                if rd_extras.get('date_obs'):
+                    #logger.info(f"rd_extras date obs: {rd_extras['date_obs']}")
+                    date_obs = datetime.fromisoformat(str(rd_extras['date_obs']).replace(' ', 'T'))
+                else:
+                    date_obs = facility.get_date_obs_from_fits_header(header)
                 break
         else:
             flux_constant = self.DEFAULT_FLUX_CONSTANT
-            if 'date_obs' in rd_extras.keys() and rd_extras.get('date_obs', ''):
-                date_obs = Time(rd_extras['date_obs']).to_datetime
+            if rd_extras.get('date_obs'):
+                #logger.info(f"rd_extras date obs in else statement: {rd_extras['date_obs']}")
+                date_obs = datetime.fromisoformat(str(rd_extras['date_obs']).replace(' ', 'T'))
             else:
                 date_obs = Time(datetime.now()).to_datetime
-
+        
+        logger.info(f"rd_extra key and values: {rd_extras.keys()} :{rd_extras.values()}")
         for keyword, possibles in self.field_keywords.items():
+            logger.info(f"keyword: {keyword}")
+
+            # Check if the keyword or any possible is already in rd_extras with a non-empty value; if so, skip this keyword
+            if (keyword in rd_extras and rd_extras.get(keyword, '')) or any(possible in rd_extras and rd_extras.get(possible, '') for possible in possibles):
+                continue
+
+            # If none are in rd_extras, check the header for each possible
             for possible in possibles:
+                logger.info(f"possible {possible} is not in rd_extras")
+            
                 if possible in header:
+        
                     value = header[possible]
-                    if keyword == "date_obs":
+                    logger.info(f"")
+                    if keyword == "date_obs" and not rd_extras.get('date_obs'):
+                        logger.info(f"line 112 date obs not in keyword or rd_extras")
                         k_lower = possible.lower()
                         if "mjd" in k_lower:
+                            logger.info(f"going through mjd in header")
                             value = Time(float(value), format="mjd").to_datetime()
                         elif "jd" in k_lower:
                             value = Time(float(value), format="jd").to_datetime()
                         else:
-                            value = Time(value).to_datetime()
+                            value = datetime.fromisoformat(str(value).replace(' ', 'T'))
                         date_obs = value
-                    if not rd_extras.get(keyword, ''):
-                        rd_extras[keyword] = value
+                    rd_extras[keyword] = value
+                    logger.info(f"keyword:value : {keyword}:{value}")
                     break
+
         dim = len(flux.shape)
         if dim == 3:
             flux = flux[0, 0, :]
@@ -91,9 +126,20 @@ class SpecProcessor(SpectroscopyProcessor):
             flux = flux[0, :]
         flux = flux * flux_constant
         header['CUNIT1'] = 'Angstrom'
-        wcs = WCS(header=header, naxis=1)
 
-        spectrum = Spectrum1D(flux=flux, wcs=wcs)
+
+        if not banzai_reduc:
+            wcs = WCS(header=header, naxis=1)
+            spectrum = Spectrum1D(flux=flux, wcs=wcs)
+        else:
+            logger.info(f"Checking for nans in flux: {np.isnan(flux).sum()}")
+
+            # Convert flux and wavelength to arrays and skip NaNs
+            flux_values = np.array(flux, dtype=float)
+            wav_values = np.array(wav, dtype=float)
+            valid_mask = ~np.isnan(flux_values)  # keep only non-NaN flux points
+            spectrum = Spectrum1D(flux=flux_values[valid_mask] * flux_constant, spectral_axis=wav_values[valid_mask] * units.Angstrom)
+            #spectrum = Spectrum1D(flux=flux, spectral_axis=np.array(wav) * units.Angstrom)
         rd_extras.pop('date_obs')
 
         return spectrum, date_obs, rd_extras


### PR DESCRIPTION
Added capability to manually upload BANZAI-FLOYDS reduced FITS files to the target page. 

This fixes a bug where the upload of any FITS file would fail if the flux column had any value that was 'None' or Nan. 
This also fixes a bug where the manual input fields upon custom upload of a FITS file were overridden automatically by the header values in the file, now any user-input in those fields overrides the default header value. This was tested with manual uploads of spectra from multiple different observatories including Gemini (North and South), SOAR, and SALT.  