### PR TITLE
Fix spec download and perms

### DIFF
--- a/custom_code/cadences/snex_resume_cadence_after_failure.py
+++ b/custom_code/cadences/snex_resume_cadence_after_failure.py
@@ -106,9 +106,11 @@ class SnexResumeCadenceAfterFailureStrategy(SnexCadencePermissionMixin, ResumeCa
         # If the observation hasn't finished, do nothing
         if not last_obs.terminal:
             return
-
+        
         if last_obs.status == 'CANCELED':
-            logger.info(f'Observation {last_obs} was canceled, not resuming cadence')
+            self.dynamic_cadence.active = False
+            self.dynamic_cadence.save()
+            logger.info(f'Observation {last_obs} was canceled, stopping dynamic cadence')
             return
 
         # Boilerplate to get necessary properties for future calls

--- a/custom_code/cadences/snex_retry_failed_observations.py
+++ b/custom_code/cadences/snex_retry_failed_observations.py
@@ -181,15 +181,7 @@ class BaseRetryStrategy(SnexCadencePermissionMixin, RetryFailedObservationsStrat
         self.sync_permissions_to_records(new_observations)
         return new_observations
 
-    def advance_window(
-        self,
-        observation_payload,
-        start_keyword='start',
-        end_keyword='end',
-        first_obs=None,
-        last_obs=None,
-        facility=None,
-    ):
+    def advance_window(self, observation_payload, start_keyword='start', end_keyword='end', first_obs=None, facility=None):
         cadence_frequency = self.dynamic_cadence.cadence_parameters.get('cadence_frequency')
         if cadence_frequency is None:
             raise Exception(

--- a/custom_code/management/commands/sync_target_data_perms.py
+++ b/custom_code/management/commands/sync_target_data_perms.py
@@ -1,0 +1,125 @@
+from itertools import islice
+from collections import defaultdict
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.contrib.contenttypes.models import ContentType
+from guardian.models import GroupObjectPermission
+from guardian.shortcuts import assign_perm
+
+from tom_targets.models import Target
+from tom_dataproducts.models import ReducedDatum, DataProduct
+from custom_code.models import ReducedDatumExtra
+
+ACTIONS = ('view', 'change', 'delete')
+
+MODELS = [
+    (ReducedDatum,      'target', 'tom_dataproducts', 'reduceddatum'),
+    (DataProduct,       'target', 'tom_dataproducts', 'dataproduct'),
+    (ReducedDatumExtra, 'target', 'custom_code',      'reduceddatumextra'),
+]
+
+def _ct(app_label, model):
+    return ContentType.objects.filter(app_label=app_label, model=model).first()
+
+
+def _chunked(iterable, n):
+    it = iter(iterable)
+    while True:
+        batch = list(islice(it, n))
+        if not batch:
+            return
+        yield batch
+
+
+class Command(BaseCommand):
+    help = "Propagate target group object-perms onto RD/RDE/DP (idempotent, resumable, memory-safe)."
+
+    def add_arguments(self, parser):
+        parser.add_argument('--dry-run', action='store_true')
+        parser.add_argument('--resume-from', type=int, default=0,
+                            help='Skip targets with pk < this (speeds up resume).')
+        parser.add_argument('--limit', type=int, default=None,
+                            help='Process at most N targets (testing).')
+        parser.add_argument('--chunk', type=int, default=500,
+                            help='Rows processed per batch (lower = less memory).')
+        parser.add_argument('--progress', type=int, default=50)
+
+    def handle(self, *args, **opts):
+        dry = opts['dry_run']
+        chunk = opts['chunk']
+        target_cts = [c for c in (_ct('custom_code', 'snextarget'),
+                                  _ct('tom_targets', 'target')) if c]
+        if not target_cts:
+            self.stderr.write('No target content types found.'); return
+
+        # Pre-resolve row content types once (not per target)
+        row_cts = {mname: _ct(app, mname) for _, _, app, mname in MODELS}
+
+        def source_perms(pk):
+            """{group: {actions}} from whichever target CT grants more groups."""
+            best = {}
+            for ct in target_cts:
+                d = defaultdict(set)
+                for g in GroupObjectPermission.objects.filter(
+                        content_type=ct, object_pk=str(pk)
+                ).select_related('group', 'permission'):
+                    act = g.permission.codename.split('_')[0]
+                    if act in ACTIONS:
+                        d[g.group].add(act)
+                if len(d) > len(best):
+                    best = dict(d)
+            return best
+
+        grand = defaultdict(int)
+        processed = skipped = 0
+
+        qs = Target.objects.filter(pk__gte=opts['resume_from']).order_by('pk')
+        if opts['limit']:
+            qs = qs[:opts['limit']]
+
+        for i, t in enumerate(qs.iterator(), 1):
+            src = source_perms(t.pk)
+            if not src:
+                if i % opts['progress'] == 0:
+                    self.stdout.write(f'... {i} seen | {processed} updated | {skipped} skipped')
+                continue
+
+            made_change = False
+            for model, fk, app, mname in MODELS:
+                ct = row_cts[mname]
+                # Stream row pks; never materialize the whole target's rows at once.
+                row_pks = model.objects.filter(**{fk: t}).values_list('pk', flat=True)
+                for batch in _chunked(row_pks.iterator(chunk_size=chunk), chunk):
+                    strs = [str(p) for p in batch]
+                    existing = set(
+                        GroupObjectPermission.objects.filter(
+                            content_type=ct, object_pk__in=strs
+                        ).values_list('group_id', 'permission__codename', 'object_pk')
+                    )
+                    for group, acts in src.items():
+                        for a in acts:
+                            codename = f'{a}_{mname}'
+                            missing = [p for p in batch
+                                       if (group.id, codename, str(p)) not in existing]
+                            if not missing:
+                                continue
+                            if not dry:
+                                with transaction.atomic():   # one txn per (chunk, group, action)
+                                    assign_perm(f'{app}.{codename}', group,
+                                                model.objects.filter(pk__in=missing))
+                            grand[f'{app}.{codename}'] += len(missing)
+                            made_change = True
+                    del existing  # release before next chunk
+
+            if made_change:
+                processed += 1
+            else:
+                skipped += 1
+
+            if i % opts['progress'] == 0:
+                self.stdout.write(f'... {i} seen | {processed} updated | {skipped} skipped')
+
+        self.stdout.write('')
+        for perm, n in sorted(grand.items()):
+            self.stdout.write(f'{"[dry] " if dry else ""}{perm}: {n} grants')
+        self.stdout.write(f'\nTotals: {processed} updated, {skipped} already-correct.')

--- a/custom_code/management/commands/update_data_product_product_ids.py
+++ b/custom_code/management/commands/update_data_product_product_ids.py
@@ -1,0 +1,30 @@
+from django.core.management.base import BaseCommand
+from custom_code.scripts.sync_databases import get_spec_row_from_filename
+from tom_dataproducts.models import DataProduct
+
+class Command(BaseCommand):
+    
+    help = 'Update the DataProduct table to have basenames as the product_id'
+
+    def handle(self, *args, **kwargs):
+        dps = DataProduct.objects.only('id', 'product_id').filter(data_product_type='spectroscopy')
+
+        batch = []
+        BATCH_SIZE = 500
+
+        for dp in dps.iterator(chunk_size=500):
+            filename = dp.data.name.split('/')[-1].replace('.ascii','.fits')
+            spec_row = get_spec_row_from_filename(filename)
+            if spec_row:
+                bname = spec_row.original
+                spec_filepath = "/".join(spec_row.filepath.split('/')[3:]) + spec_row.filename.replace('ascii', 'fits')
+                print(dp.product_id, dp.data.name)
+                dp.product_id = bname
+                dp.data.name = spec_filepath
+                batch.append(dp)
+            if len(batch) >= BATCH_SIZE:
+                DataProduct.objects.bulk_update(batch, ['product_id', 'data'])
+                batch.clear()
+
+        if batch:
+            DataProduct.objects.bulk_update(batch, ['product_id', 'data'])

--- a/custom_code/scripts/sync_databases.py
+++ b/custom_code/scripts/sync_databases.py
@@ -20,16 +20,7 @@ from tom_targets.models import Target, TargetName
 import logging
 logger = logging.getLogger(__name__)
 
-_SNEX2_DB = 'postgresql://{}:{}@{}:{}/snex2'.format(
-    os.environ.get('SNEX2_DB_USER'),
-    os.getenv('SNEX2_DB_PASSWORD'),
-    os.getenv('SNEX2_DB_HOST', 'snex2-db'),
-    os.getenv('SNEX2_DB_PORT', 5432)
-)
-
 engine1 = create_engine(settings.SNEX1_DB_URL)
-engine2 = create_engine(_SNEX2_DB)
-
 
 @contextmanager
 def get_session(db_address=settings.SNEX1_DB_URL):
@@ -44,9 +35,7 @@ def get_session(db_address=settings.SNEX1_DB_URL):
     if db_address == settings.SNEX1_DB_URL:
         Base.metadata.bind = engine1
         db_session = sessionmaker(bind=engine1, autoflush=False, expire_on_commit=False)
-    else:
-        Base.metadata.bind = engine2
-        db_session = sessionmaker(bind=engine2, autoflush=False, expire_on_commit=False)
+
     session = db_session()
     try:
         yield session
@@ -127,6 +116,13 @@ def get_current_row(table, id_, db_address=settings.SNEX1_DB_URL):
     with get_session(db_address=db_address) as db_session:
         criteria = getattr(table, 'id') == id_
         record = db_session.query(table).filter(criteria).first()
+    return record
+
+
+def get_spec_row_from_filename(filename, db_address=settings.SNEX1_DB_URL):
+    with get_session(db_address=db_address) as db_session:
+            criteria = getattr(Spec, 'filename') == filename
+            record = db_session.query(Spec).filter(criteria).first()
     return record
 
 
@@ -311,6 +307,7 @@ def update_spec(action):
 
                 pipeline_id = spec_row.targetid
                 time = '{} {}'.format(spec_row.dateobs, spec_row.ut)
+                spec_filepath = "/".join(spec_row.filepath.split('/')[3:]) + spec_row.filename.replace('ascii', 'fits')  #remove everything before 'WEB/floyds/date_tel', e.g.: 'WEB/floyds/20240325_2m0-01/SN2024ehs_20240325_redblu_104630.842.fits'
                 spec_filename = os.path.join(spec_row.filepath.replace(settings.SN_DIR, '/snex2/'), spec_row.filename.replace('.fits', '.ascii'))
                 spec = read_spec(spec_filename)
                 spec_groupid = spec_row.groupidcode
@@ -330,11 +327,11 @@ def update_spec(action):
                     #created True means new DataProduct was made, created False is object already existed, like just "get"
                     data_product, dp_created = DataProduct.objects.get_or_create(
                         target = target, 
-                        product_id = spec_row.filename.replace('.fits', '.ascii'),
+                        product_id = spec_row.original.replace('.fits',''),
                         data_product_type = 'spectroscopy')
                     
                     if dp_created:
-                        data_product.data = data_product_path(data_product, spec_row.filename.replace('.fits', '.ascii'))
+                        data_product.data = spec_filepath
                         data_product.created = time
                         data_product.modified = time
                         data_product.featured = False
@@ -381,7 +378,7 @@ def update_spec(action):
 
         
 
-def update_target(action, db_address=_SNEX2_DB):
+def update_target(action, db_address=settings.SNEX1_DB_URL):
     """
     Queries the Target table in the SNex2 db with any changes made to the Targets and Targetnames tables in the SNex1 db
 
@@ -479,5 +476,5 @@ def run():
         update_spec(action)
         logger.info('Done with spectra')
         if action != 'delete':
-            update_target(action, db_address = _SNEX2_DB)
+            update_target(action, db_address = settings.SNEX1_DB_URL)
             logger.info('Done with targets')

--- a/custom_code/urls.py
+++ b/custom_code/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from custom_code.views import TNSTargets, PaperCreateView, PaperUpdateView, PaperDeleteView, scheduling_view, ReferenceStatusUpdateView, ObservationGroupDetailView, observation_sequence_cancel_view, AuthorshipInformation, download_photometry_view, get_target_standards_view, SNEx2SpectroscopyTNSSharePassthrough, CustomUserUpdateView, TargetFilteringView, download_data_product_view
+from custom_code.views import BulkDownloadView, TNSTargets, PaperCreateView, PaperUpdateView, PaperDeleteView, scheduling_view, ReferenceStatusUpdateView, ObservationGroupDetailView, observation_sequence_cancel_view, AuthorshipInformation, download_photometry_view, get_target_standards_view, SNEx2SpectroscopyTNSSharePassthrough, CustomUserUpdateView, TargetFilteringView, download_data_product_view
 
 app_name = 'custom_code'
 
@@ -20,4 +20,5 @@ urlpatterns = [
     path('tns-share-spectrum/<int:pk>/<int:datum_pk>', SNEx2SpectroscopyTNSSharePassthrough.as_view(), name='tns-share-spectrum'),
     path('users/<int:pk>/update/', CustomUserUpdateView.as_view(), name='custom-user-update'),
     path('target_filter/', TargetFilteringView.as_view(), name='target_filter'),
+    path('dataproducts/bulk-download/', BulkDownloadView.as_view(), name='bulk-download-dataproducts')
 ]

--- a/custom_code/urls.py
+++ b/custom_code/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from custom_code.views import TNSTargets, PaperCreateView, PaperUpdateView, PaperDeleteView, scheduling_view, ReferenceStatusUpdateView, ObservationGroupDetailView, observation_sequence_cancel_view, AuthorshipInformation, download_photometry_view, get_target_standards_view, SNEx2SpectroscopyTNSSharePassthrough, CustomUserUpdateView, TargetFilteringView
+from custom_code.views import TNSTargets, PaperCreateView, PaperUpdateView, PaperDeleteView, scheduling_view, ReferenceStatusUpdateView, ObservationGroupDetailView, observation_sequence_cancel_view, AuthorshipInformation, download_photometry_view, get_target_standards_view, SNEx2SpectroscopyTNSSharePassthrough, CustomUserUpdateView, TargetFilteringView, download_data_product_view
 
 app_name = 'custom_code'
 
@@ -15,9 +15,9 @@ urlpatterns = [
     path('observation/cancel/', observation_sequence_cancel_view, name='observation-sequence-cancel'),
     path('authorshipinformation/', AuthorshipInformation.as_view(), name='authorship'),
     path('download-photometry/<int:targetid>/', download_photometry_view, name='download-photometry'),
+    path('download-dataproduct/<int:pk>/', download_data_product_view, name='download-dataproduct'),
     path('get-target-standards/', get_target_standards_view, name='get-target-standards'),
     path('tns-share-spectrum/<int:pk>/<int:datum_pk>', SNEx2SpectroscopyTNSSharePassthrough.as_view(), name='tns-share-spectrum'),
     path('users/<int:pk>/update/', CustomUserUpdateView.as_view(), name='custom-user-update'),
     path('target_filter/', TargetFilteringView.as_view(), name='target_filter'),
-
 ]

--- a/custom_code/views.py
+++ b/custom_code/views.py
@@ -1702,7 +1702,7 @@ class BulkDownloadView(LoginRequiredMixin, View):
                 written += 1
 
         if written == 0:
-            return HttpResponse('No downloadable files found for selection.', status=404)
+            return JsonResponse({'error': 'No downloadable files found for selection.'}, status=404)
 
         zip_buffer.seek(0)
         response = HttpResponse(zip_buffer.getvalue(), content_type='application/zip')

--- a/custom_code/views.py
+++ b/custom_code/views.py
@@ -3,6 +3,7 @@ import json
 import os
 from datetime import date, datetime, timedelta
 from io import BytesIO, StringIO
+import zipfile
 import requests
 from astropy import units as u
 from astropy.coordinates import SkyCoord
@@ -13,6 +14,7 @@ from django import forms
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.models import Group, User
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
 from django.core.cache import cache
@@ -1179,7 +1181,19 @@ def load_manage_data_tab_view(request):
         # Get the template tag contexts
         upload_context = custom_code_tags.custom_upload_dataproduct(context_dict, target) if request.user.is_authenticated else None
         dataproduct_context = dataproduct_list_for_target(context_dict, target)
-        
+        telescopes, instruments = set(), set()
+        for p in dataproduct_context['products']:
+            rde = p.reduceddatumextra_set.first()
+            if rde and rde.value:
+                t = rde.value.get('telescope')
+                i = rde.value.get('instrument')
+                if t:
+                    telescopes.add(t)
+                if i:
+                    instruments.add(i)
+        dataproduct_context['telescopes'] = sorted(telescopes)
+        dataproduct_context['instruments'] = sorted(instruments)
+
         # Render the components
         upload_html = render_to_string('custom_code/custom_upload_dataproduct.html', upload_context, request=request) if upload_context else ''
         dataproduct_html = render_to_string('tom_dataproducts/partials/dataproduct_list_for_target.html', dataproduct_context, request=request)
@@ -1196,7 +1210,6 @@ def load_manage_data_tab_view(request):
         )
         return JsonResponse({'html': html}, safe=False)
     return JsonResponse({'html': '<div>Error loading manage data</div>'}, safe=False)
-
 
 
 def load_observing_runs_tab_view(request):
@@ -1649,6 +1662,53 @@ def download_fits_view(request):
     data = requests.get(results[0]["url"]).content
 
     return FileResponse(BytesIO(data),filename=object_basename+'.fits', as_attachment=True)
+
+
+class BulkDownloadView(LoginRequiredMixin, View):
+    def post(self, request, *args, **kwargs):
+        product_ids = request.POST.getlist('selected_products')
+        target_name = request.POST.get('target_name', 'snextarget')
+        clean_target_name = target_name.replace(' ', '_')
+        download_format = request.POST.get('download_format', 'fits')
+
+        if not product_ids:
+            return HttpResponse('No items selected.', status=400)
+
+        allowed = get_objects_for_user(
+            request.user, 'tom_dataproducts.view_dataproduct',
+            klass=DataProduct.objects.filter(id__in=product_ids),
+        )
+
+        zip_buffer = BytesIO()
+        written = 0
+        with zipfile.ZipFile(zip_buffer, 'w', zipfile.ZIP_DEFLATED) as zip_file:
+            for product in allowed:
+                if not product.data:
+                    continue
+                file_name = product.get_file_name()
+
+                if download_format == 'ascii':
+                    src_path = os.path.splitext(product.data.path)[0] + '.ascii'
+                    if not os.path.exists(src_path):
+                        continue
+                    arc_name = os.path.splitext(file_name)[0] + '.ascii'
+                else:
+                    src_path = product.data.path
+                    if not os.path.exists(src_path):
+                        continue
+                    arc_name = file_name
+
+                zip_file.write(src_path, arcname=arc_name)
+                written += 1
+
+        if written == 0:
+            return HttpResponse('No downloadable files found for selection.', status=404)
+
+        zip_buffer.seek(0)
+        response = HttpResponse(zip_buffer.getvalue(), content_type='application/zip')
+        response['Content-Disposition'] = f'attachment; filename={clean_target_name}_{download_format}.zip'
+        return response
+
 
 @require_GET
 def get_frame_ids_view(request):

--- a/custom_code/views.py
+++ b/custom_code/views.py
@@ -20,7 +20,7 @@ from django.db.models import Count, DateTimeField, Exists, ExpressionWrapper, F,
 from django.db.models.fields.json import KeyTextTransform
 from django.db.models.functions import Cast
 from django.shortcuts import redirect, render, get_object_or_404
-from django.http import HttpResponse, JsonResponse, HttpResponseRedirect, FileResponse, StreamingHttpResponse, HttpResponseBadRequest, HttpResponseForbidden, QueryDict
+from django.http import HttpResponse, JsonResponse, HttpResponseRedirect, FileResponse, StreamingHttpResponse, HttpResponseBadRequest, HttpResponseForbidden, QueryDict, Http404
 from django.views.decorators.http import require_POST, require_GET
 from django.views.generic.base import TemplateView, RedirectView
 from django.views.generic.list import ListView
@@ -1625,6 +1625,16 @@ def make_thumbnail_view(request):
                     }
 
     return HttpResponse(json.dumps(content_response), content_type='application/json')
+
+def download_data_product_view(request, pk):
+    dp = get_object_or_404(DataProduct, pk=pk)
+    if not request.user.has_perm('tom_dataproducts.view_dataproduct', dp):
+        return HttpResponseForbidden('Not authorized')
+    if not dp.data or not os.path.exists(dp.data.path):
+        raise Http404('File not found on disk')
+    return FileResponse(open(dp.data.path, 'rb'),
+                        as_attachment=True,
+                        filename=os.path.basename(dp.data.name))
 
 def download_fits_view(request):
     token = settings.FACILITIES['LCO']['api_key']

--- a/snex2/settings.py
+++ b/snex2/settings.py
@@ -269,7 +269,7 @@ STATICFILES_FINDERS = [
     'django_plotly_dash.finders.DashComponentFinder',
     'django_plotly_dash.finders.DashAppDirectoryFinder',
 ]
-MEDIA_ROOT = os.path.join(BASE_DIR, 'data')
+MEDIA_ROOT = os.path.join(BASE_DIR, 'data', 'WEB', 'floyds')
 MEDIA_URL = '/data/'
 
 LOGGING = {

--- a/templates/tom_dataproducts/partials/dataproduct_list_for_target.html
+++ b/templates/tom_dataproducts/partials/dataproduct_list_for_target.html
@@ -15,10 +15,11 @@
       {% endif %}
       <td>
         {%  if 'fits' in product.get_file_name or product.data_product_type == 'fits_file' %}
-          {% include 'tom_dataproducts/partials/js9_button.html' with url=product.data.url only %}
+          {% url 'custom_code:download-dataproduct' pk=product.id as js9_url %}
+          {% include 'tom_dataproducts/partials/js9_button.html' with url=js9_url only %}
         {% endif %}
       </td>
-      <td><a href="{{ product.data.url }}">{{ product.get_file_name }}</a></td>
+      <td><a href="{% url 'custom_code:download-dataproduct' product.id %}">{{ product.get_file_name }}</a></td>
       <td>
         {% if product.data_product_type %}
           {{ product.get_type_display }}

--- a/templates/tom_dataproducts/partials/dataproduct_list_for_target.html
+++ b/templates/tom_dataproducts/partials/dataproduct_list_for_target.html
@@ -2,33 +2,145 @@
 {% load custom_code_tags %}
 {% include 'tom_dataproducts/partials/js9_scripts.html' %}
 <h4>Data</h4>
-<table class="table table-striped">
-  <thead><tr><th></th><th></th><th>Filename</th><th>Type</th><th>Update</th><th>Delete</th></tr></thead>
-  <tbody>
-  {% for product in products %}
-    {% if product.data %}
-    <tr>
-      {% if not product.featured %}
-      <td><a href="{% url 'tom_dataproducts:feature' pk=product.id %}?target_id={{ target.id }}" title="Make Featured Image" class="btn btn-primary">Feature</a></td>
-      {% else %}
-      <td><span class="btn btn-secondary active featured">Featured</span></td>
+<div class="row mb-3 bg-light p-3 rounded">
+  <div class="col-md-3">
+    <label for="startDateFilter" class="font-weight-bold">Start Date:</label>
+    <input type="date" id="startDateFilter" class="form-control product-filter">
+  </div>
+  <div class="col-md-3">
+    <label for="endDateFilter" class="font-weight-bold">End Date:</label>
+    <input type="date" id="endDateFilter" class="form-control product-filter">
+  </div>
+  <div class="col-md-2">
+    <label for="telescopeFilter" class="font-weight-bold">Telescope:</label>
+    <select id="telescopeFilter" class="form-control product-filter">
+      <option value="">-- All --</option>
+      {% for t in telescopes %}<option value="{{ t }}">{{ t }}</option>{% endfor %}
+    </select>
+  </div>
+  <div class="col-md-2">
+    <label for="instrumentFilter" class="font-weight-bold">Instrument:</label>
+    <select id="instrumentFilter" class="form-control product-filter">
+      <option value="">-- All --</option>
+      {% for i in instruments %}<option value="{{ i }}">{{ i }}</option>{% endfor %}
+    </select>
+  </div>
+  <div class="col-md-2 d-flex align-items-end">
+    <button type="button" id="clearFilters" class="btn btn-secondary btn-block">Clear Filters</button>
+  </div>
+</div>
+<form action="{% url 'custom_code:bulk-download-dataproducts' %}" method="POST" id="bulkDownloadForm">
+  {% csrf_token %}
+  <input type="hidden" name="target_name" value="{{ target.name }}">
+  <div class="mb-3 d-inline-block">
+    <button type="submit" name="download_format" value="fits" class="btn btn-success">Download as fits (.zip)</button>
+  </div>
+  <div class="mb-3 d-inline-block">
+    <button type="submit" name="download_format" value="ascii" class="btn btn-success">Download as ascii (.zip)</button>
+  </div>
+  <table class="table table-striped" id="dataproductsTable">
+    <thead>
+      <tr>
+        <th><input type="checkbox" id="selectAll"></th>
+        <th></th>
+        <th></th>
+        <th>Filename</th>
+        <th>Type</th>
+        <th>Update</th>
+        <th>Delete</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for product in products %}
+      {% if product.data %}
+      {% with extra=product.reduceddatumextra_set.first %}
+      <tr class="product-row"
+          data-created="{{ product.created|date:'Y-m-d' }}"
+          data-telescope="{{ extra.value.telescope|default:'' }}"
+          data-instrument="{{ extra.value.instrument|default:'' }}">
+        <td>
+          <input type="checkbox" name="selected_products" value="{{ product.id }}" class="product-checkbox">
+        </td>
+        {% if not product.featured %}
+        <td><a href="{% url 'tom_dataproducts:feature' pk=product.id %}?target_id={{ target.id }}" title="Make Featured Image" class="btn btn-primary">Feature</a></td>
+        {% else %}
+        <td><span class="btn btn-secondary active featured">Featured</span></td>
+        {% endif %}
+        <td>
+          {% if 'fits' in product.get_file_name or product.data_product_type == 'fits_file' %}
+            {% url 'custom_code:download-dataproduct' pk=product.id as js9_url %}
+            {% include 'tom_dataproducts/partials/js9_button.html' with url=js9_url only %}
+          {% endif %}
+        </td>
+        <td><a href="{% url 'custom_code:download-dataproduct' product.id %}">{{ product.get_file_name }}</a></td>
+        <td>
+          {% if product.data_product_type %}
+            {{ product.get_type_display }}
+          {% endif %}
+        </td>
+        <td>{% dataproduct_update product %}</td>
+        <td><a href="{% url 'tom_dataproducts:delete' product.id %}" class="btn btn-danger">Delete</a></td>
+      </tr>
+      {% endwith %}
       {% endif %}
-      <td>
-        {%  if 'fits' in product.get_file_name or product.data_product_type == 'fits_file' %}
-          {% url 'custom_code:download-dataproduct' pk=product.id as js9_url %}
-          {% include 'tom_dataproducts/partials/js9_button.html' with url=js9_url only %}
-        {% endif %}
-      </td>
-      <td><a href="{% url 'custom_code:download-dataproduct' product.id %}">{{ product.get_file_name }}</a></td>
-      <td>
-        {% if product.data_product_type %}
-          {{ product.get_type_display }}
-        {% endif %}
-        </a>
-      </td>
-      <td>{% dataproduct_update product %}</td>
-      <td><a href="{% url 'tom_dataproducts:delete' product.id %}" class="btn btn-danger">Delete</a></td>
-    </tr>
-    {% endif %}
-  {% endfor %}
-</table>
+    {% endfor %}
+    </tbody>
+  </table>
+</form>
+<script>
+(function () {
+  if (window.__dataProductFiltersBound) { return; }
+  window.__dataProductFiltersBound = true;
+
+  function filterTable() {
+    const start = document.getElementById('startDateFilter');
+    const end = document.getElementById('endDateFilter');
+    const tel = document.getElementById('telescopeFilter');
+    const ins = document.getElementById('instrumentFilter');
+    if (!start) { return; }   // partial not present yet
+    const startVal = start.value;
+    const endVal = end.value;
+    const selTel = (tel.value || '').toLowerCase();
+    const selIns = (ins.value || '').toLowerCase();
+    document.querySelectorAll('.product-row').forEach(function (row) {
+      const d = row.getAttribute('data-created') || '';
+      const okStart = !startVal || d >= startVal;
+      const okEnd = !endVal || d <= endVal;
+      const okTel = !selTel || (row.getAttribute('data-telescope') || '').toLowerCase() === selTel;
+      const okIns = !selIns || (row.getAttribute('data-instrument') || '').toLowerCase() === selIns;
+      const show = okStart && okEnd && okTel && okIns;
+      row.style.display = show ? '' : 'none';
+      if (!show) {
+        const cb = row.querySelector('.product-checkbox');
+        if (cb) { cb.checked = false; }
+      }
+    });
+  }
+  document.addEventListener('change', function (ev) {
+    const t = ev.target;
+    if (t.classList && t.classList.contains('product-filter')) {
+      filterTable();
+    } else if (t.id === 'selectAll') {
+      document.querySelectorAll('.product-row:not([style*="display: none"]) .product-checkbox')
+        .forEach(function (cb) { cb.checked = t.checked; });
+    }
+  });
+  document.addEventListener('click', function (ev) {
+    if (ev.target.id === 'clearFilters') {
+      ['startDateFilter', 'endDateFilter', 'telescopeFilter', 'instrumentFilter'].forEach(function (id) {
+        const el = document.getElementById(id);
+        if (el) { el.value = ''; }
+      });
+      filterTable();
+    }
+  });
+  document.addEventListener('submit', function (ev) {
+    if (ev.target.id === 'bulkDownloadForm') {
+      if (!document.querySelectorAll('.product-checkbox:checked').length) {
+        ev.preventDefault();
+        alert("No items selected. Please check at least one data product before downloading.");
+      }
+    }
+  });
+})();
+</script>

--- a/templates/tom_dataproducts/partials/dataproduct_list_for_target.html
+++ b/templates/tom_dataproducts/partials/dataproduct_list_for_target.html
@@ -38,6 +38,7 @@
   <div class="mb-3 d-inline-block">
     <button type="submit" name="download_format" value="ascii" class="btn btn-success">Download as ascii (.zip)</button>
   </div>
+</form>
   <table class="table table-striped" id="dataproductsTable">
     <thead>
       <tr>
@@ -46,6 +47,7 @@
         <th></th>
         <th>Filename</th>
         <th>Type</th>
+        <th>Date</th>
         <th>Update</th>
         <th>Delete</th>
       </tr>
@@ -78,6 +80,11 @@
             {{ product.get_type_display }}
           {% endif %}
         </td>
+        <td>
+          {% with rd=product.reduceddatum_set.first %}
+            {{ rd.timestamp|date:"Y-m-d" }}
+          {% endwith %}
+        </td>
         <td>{% dataproduct_update product %}</td>
         <td><a href="{% url 'tom_dataproducts:delete' product.id %}" class="btn btn-danger">Delete</a></td>
       </tr>
@@ -86,7 +93,6 @@
     {% endfor %}
     </tbody>
   </table>
-</form>
 <script>
 (function () {
   if (window.__dataProductFiltersBound) { return; }

--- a/templates/tom_dataproducts/partials/dataproduct_list_for_target.html
+++ b/templates/tom_dataproducts/partials/dataproduct_list_for_target.html
@@ -135,12 +135,42 @@
     }
   });
   document.addEventListener('submit', function (ev) {
-    if (ev.target.id === 'bulkDownloadForm') {
-      if (!document.querySelectorAll('.product-checkbox:checked').length) {
-        ev.preventDefault();
-        alert("No items selected. Please check at least one data product before downloading.");
-      }
+    if (ev.target.id !== 'bulkDownloadForm') return;
+    ev.preventDefault();
+    const form = ev.target;
+    if (!document.querySelectorAll('.product-checkbox:checked').length) {
+      alert("No items selected. Please check at least one data product before downloading.");
+      return;
     }
+    const formData = new FormData(form);
+    const fmt = ev.submitter ? ev.submitter.value : 'fits';
+    formData.set('download_format', fmt);
+    fetch(form.action, {
+      method: 'POST',
+      body: formData,
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+    }).then(function (resp) {
+      const ct = resp.headers.get('Content-Type') || '';
+      if (ct.indexOf('application/zip') !== -1) {
+        return resp.blob().then(function (blob) {
+          const cd = resp.headers.get('Content-Disposition') || '';
+          const m = cd.match(/filename=([^;]+)/);
+          const name = m ? m[1].replace(/["']/g, '').trim() : 'download.zip';
+          const url = URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url; a.download = name;
+          document.body.appendChild(a); a.click(); a.remove();
+          URL.revokeObjectURL(url);
+        });
+      }
+      return resp.json().then(function (data) {
+        alert(data.error || 'Download failed.');
+      }).catch(function () {
+        alert('Download failed.');
+      });
+    }).catch(function () {
+      alert('Download failed. Please try again.');
+    });
   });
 })();
 </script>


### PR DESCRIPTION
Added ability to download the fits or ascii files from spectra from the data management tab. Form values can select all filtered by telescope, instrument, or date range. These can be downloaded as fits or ascii, if available.

This also adds 2 management commands to update the dataproducts to have their filepaths populated by the supernova database and change their product_id to be the basename (frameid isn't unique enough). The sync databases script was also updated to make the data product path the on in the spec table so future Floyds reductions will follow this format.

Uploaded files are in the correct MEDIA_ROOT directory from the settings.py, so clicking on the filename from the data management tab works to download them. This will need to be tested on a before deploying to ensure the uploaded files are in the proper directories. The management commands address this but further testing may be required or the management commands merged into prod before the template.